### PR TITLE
support python3.4 by importing contextlib2 if import of contextlib fails

### DIFF
--- a/jsonargparse.py
+++ b/jsonargparse.py
@@ -1,4 +1,3 @@
-
 import os
 import re
 import sys
@@ -12,7 +11,11 @@ from argparse import Action, OPTIONAL, REMAINDER, SUPPRESS, PARSER, ONE_OR_MORE,
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, List, Dict, Set, Union
-from contextlib import contextmanager, redirect_stderr
+try:
+    from contextlib import contextmanager, redirect_stderr
+except:
+    from contextlib2 import contextmanager, redirect_stderr
+
 
 try:
     import jsonschema


### PR DESCRIPTION
I've experienced some issues on older distributions with python 3.4
contextlib is standard starting python 3.5, there's a project called [contextlib2]([https://contextlib2.readthedocs.io/en/stable/) that seems to be maintained 

This PR works fine with the tests I've done