### PR TITLE
Fix parse_args return type

### DIFF
--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -178,7 +178,7 @@ class ArgumentParser(SignatureArguments, _ActionsContainer, argparse.ArgumentPar
             with_meta (bool): Whether to include metadata in config object.
 
         Returns:
-            Namespace: An object with all parsed values as nested attributes.
+            Namespace or Dict: An object with all parsed values as nested attributes.
 
         Raises:
             ParserError: If there is a parsing error and error_handler=None.


### PR DESCRIPTION
To avoid `Expected type 'Dict[str, Any]', got 'Namespace' instead ` when `parse_as_dict=True` is used.

Some functions use type hints in the signature/return, others in the docstring, others in both. I changed only the docstring here because it is what it had.

Thanks!