### PR TITLE
Fix error when using builtins.type type hint (Issue #76)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Added
 - Support for parsing ``Mapping`` and ``MutableMapping`` types.
 - Support for parsing ``frozenset``, ``MutableSequence`` and ``MutableSet`` types.
 
+Changed
+^^^^^^^
+- Docstrings no longer supported for python 3.5.
+
 
 v3.17.0 (2021-07-19)
 --------------------

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -346,11 +346,11 @@ def adapt_typehints(val, typehint, serialize=False, instantiate_classes=False, s
     elif typehint in {Type, type} or typehint_origin in {Type, type}:
         if serialize:
             val = object_path_serializer(val)
-        elif not serialize and not isinstance(val, Type):
+        elif not serialize and not isinstance(val, type):
             path = val
             val = import_object(val)
-            if (typehint in {Type, type} and not isinstance(val, (Type, type))) or \
-               (typehint != Type and typehint_origin in {Type, type} and not _issubclass(val, subtypehints[0])):
+            if (typehint in {Type, type} and not isinstance(val, type)) or \
+               (typehint not in {Type, type} and not _issubclass(val, subtypehints[0])):
                 raise ValueError('Value "'+str(path)+'" is not a '+str(typehint)+'.')
 
     # Union

--- a/jsonargparse_tests/typehints_tests.py
+++ b/jsonargparse_tests/typehints_tests.py
@@ -209,18 +209,37 @@ class TypeHintsTests(unittest.TestCase):
         self.assertRaises(ParserError, lambda: parser.parse_args(['--false=true']))
 
 
-    def test_type_Type(self):
+    def _test_typehint_non_parameterized_types(self, type):
         parser = ArgumentParser(error_handler=None)
-        ActionTypeHint.is_supported_typehint(Type, full=True)
-        parser.add_argument('--type', type=Type)
-        parser.add_argument('--cal', type=Type[Calendar])
+        ActionTypeHint.is_supported_typehint(type, full=True)
+        parser.add_argument('--type', type=type)
         cfg = parser.parse_args(['--type=uuid.UUID'])
         self.assertEqual(cfg.type, uuid.UUID)
         self.assertEqual(parser.dump(cfg), 'type: uuid.UUID\n')
+
+
+    def _test_typehint_parameterized_types(self, type):
+        parser = ArgumentParser(error_handler=None)
+        ActionTypeHint.is_supported_typehint(type, full=True)
+        parser.add_argument('--cal', type=type[Calendar])
         cfg = parser.parse_args(['--cal=calendar.Calendar'])
         self.assertEqual(cfg.cal, Calendar)
         self.assertEqual(parser.dump(cfg), 'cal: calendar.Calendar\n')
         self.assertRaises(ParserError, lambda: parser.parse_args(['--cal=uuid.UUID']))
+
+
+    def test_typehint_Type(self):
+        self._test_typehint_non_parameterized_types(type=Type)
+        self._test_typehint_parameterized_types(type=Type)
+
+
+    def test_typehint_non_parameterized_type(self):
+        self._test_typehint_non_parameterized_types(type=type)
+
+
+    @unittest.skipIf(sys.version_info[:2] < (3, 9), '[] support for builtins introduced in python 3.9')
+    def test_typehint_parametrized_type(self):
+        self._test_typehint_parameterized_types(type=type)
 
 
     def test_uuid(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ all =
     %(typing_extensions)s
     %(reconplogger)s
 signatures =
-    docstring-parser>=0.7.3
+    docstring-parser>=0.7.3; python_version >= '3.6'
 jsonschema =
     jsonschema>=3.2.0
 jsonnet =


### PR DESCRIPTION
Fixes #76 and adds corresponding test case. 

In addition, in `isinstance()` calls `typing.Type` has been replaced with `builtins.type` because the former is deprecated since Python version 3.9 and currently is just an alias for the latter.