### PR TITLE
Set `SUPPRESS` as the default value for `add_subclass_arguments`

### DIFF
--- a/jsonargparse/signatures.py
+++ b/jsonargparse/signatures.py
@@ -2,7 +2,7 @@
 
 import inspect
 import re
-from argparse import Namespace
+from argparse import Namespace, SUPPRESS
 from functools import wraps
 from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
@@ -491,7 +491,7 @@ class SignatureArguments:
             {},
             added_args,
             skip,
-            default={},
+            default=SUPPRESS,
             sub_configs=True,
             instantiate=instantiate,
             **kwargs

--- a/jsonargparse_tests/signatures_tests.py
+++ b/jsonargparse_tests/signatures_tests.py
@@ -386,7 +386,9 @@ class SignaturesTests(unittest.TestCase):
         parser = ArgumentParser(parse_as_dict=True, error_handler=None)
         parser.add_subclass_arguments(calendar.Calendar, 'cal', required=False)
         cfg = parser.parse_args([])
-        self.assertEqual(cfg, {'cal': {}})
+        self.assertEqual(cfg, {})
+        cfg_init = parser.instantiate_classes(cfg)
+        self.assertEqual(cfg_init, {})
 
 
     def test_invalid_type(self):


### PR DESCRIPTION
Fixes #83

This `if` will now work:

https://github.com/omni-us/jsonargparse/blob/dde80fb00f48e3a922001542c47f16c986df7fd2/jsonargparse/core.py#L951