### PR TITLE
Relax constraint on env_prefix when reading from environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,20 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in any moment.
 
 
+v4.11.0 (2022-07-??)
+--------------------
+
+Added
+^^^^^
+- ``env_prefix`` property now also accepts boolean. If set to False,
+when default env feature is enabled, it won't add any prefix when reading
+parameters from environment variables.
+
+Deprecated
+^^^^^^^^^^
+- ``env_prefix`` property will no longer accept ``None`` in v5.0.0.
+
+
 v4.10.3 (2022-07-??)
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1693,9 +1693,9 @@ Environment variables
 The jsonargparse parsers can also get values from environment variables. The
 parser checks existing environment variables whose name is of the form
 ``[PREFIX_][LEV__]*OPT``, that is, all in upper case, first a prefix (set by
-``env_prefix``, or if unset the ``prog`` without extension) followed by
-underscore and then the argument name replacing dots with two underscores. Using
-the parser from the :ref:`nested-namespaces` section above, in your shell you
+``env_prefix``, or if unset the ``prog`` without extension or none if set to False)
+followed by underscore and then the argument name replacing dots with two underscores.
+Using the parser from the :ref:`nested-namespaces` section above, in your shell you
 would set the environment variables as:
 
 .. code-block:: bash

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -817,7 +817,7 @@ def parent_parsers_context(key, parser):
 class _ActionSubCommands(_SubParsersAction):
     """Extension of argparse._SubParsersAction to modify subcommands functionality."""
 
-    _env_prefix: Optional[str] = None
+    _env_prefix: Union[bool, str] = True
 
 
     def add_parser(self, name, **kwargs):

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -162,7 +162,7 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
     def __init__(
         self,
         *args,
-        env_prefix: Optional[str] = None,
+        env_prefix: Union[bool, str] = True,
         error_handler: Optional[Callable[['ArgumentParser', str], None]] = usage_and_exit_error_handler,
         formatter_class: Type[DefaultHelpFormatter] = DefaultHelpFormatter,
         logger: Union[bool, str, dict, logging.Logger] = False,
@@ -1390,7 +1390,7 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
 
 
     @property
-    def env_prefix(self) -> Optional[str]:
+    def env_prefix(self) -> Union[bool, str]:
         """The environment variables prefix property.
 
         :getter: Returns the current environment variables prefix.
@@ -1399,12 +1399,17 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
         Raises:
             ValueError: If an invalid value is given.
         """
-        return self._env_prefix
+        return self._env_prefix  # type: ignore
 
 
     @env_prefix.setter
-    def env_prefix(self, env_prefix: Optional[str]):
-        if env_prefix is None:
+    def env_prefix(self, env_prefix: Union[bool, str]):
+        if env_prefix is False:
+            self._env_prefix = None
+        elif env_prefix in {True, None}:
+            if env_prefix is None:
+                from .deprecated import deprecation_warning, env_prefix_property_none_message
+                deprecation_warning(ArgumentParser, env_prefix_property_none_message)
             self._env_prefix = os.path.splitext(self.prog)[0]
         elif isinstance(env_prefix, str):
             self._env_prefix = env_prefix

--- a/jsonargparse/deprecated.py
+++ b/jsonargparse/deprecated.py
@@ -250,3 +250,8 @@ logger_property_none_message = """
     Setting the logger property to None was deprecated in v4.10.0 and will raise
     an exception in v5.0.0. Use False instead.
 """
+
+env_prefix_property_none_message = """
+    Setting the env_prefix property to None was deprecated in v4.11.0 and will raise
+    an exception in v5.0.0. Use True instead.
+"""

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -166,6 +166,24 @@ class ParsersTests(TempDirTestCase):
             self.assertFalse(parser.default_env)
 
 
+    def test_env_prefix(self):
+        parser = ArgumentParser(env_prefix=True, default_env=True, error_handler=None)
+        parser.add_argument("--test_arg", type=str, required=True, help="Test argument")
+        with self.assertRaises(ParserError):
+            with unittest.mock.patch.dict(os.environ, {'TEST_ARG': 'one'}):
+                parser.parse_args([])
+        prefix = os.path.splitext(parser.prog)[0].upper()
+        with unittest.mock.patch.dict(os.environ, {f'{prefix}_TEST_ARG': 'one'}):
+            cfg = parser.parse_args([])
+            self.assertEqual('one', cfg.test_arg)
+
+        parser = ArgumentParser(env_prefix=False, default_env=True)
+        parser.add_argument("--test_arg", type=str, required=True, help="Test argument")
+        with unittest.mock.patch.dict(os.environ, {'TEST_ARG': 'one'}):
+            cfg = parser.parse_args([])
+            self.assertEqual('one', cfg.test_arg)
+
+
     def test_parse_string(self):
         parser = example_parser()
 

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -171,6 +171,12 @@ class DeprecatedTests(unittest.TestCase):
             self.assertIn(' Setting the logger property to None was deprecated', str(w[-1].message))
 
 
+    def test_env_prefix_none(self):
+        with catch_warnings(record=True) as w:
+            ArgumentParser(env_prefix=None)
+            self.assertIn('env_prefix', str(w[-1].message))
+
+
 class DeprecatedTempDirTests(TempDirTestCase):
 
     def test_parse_as_dict(self):


### PR DESCRIPTION
Reading parameters from environment is a great feature, but user
can sometimes want to not have any prefix when reading environement
variables.
This patch introduces another parameter named empty_env_prefix,
that if set to True, will initialize env_prefix to None, and hence unlock
what has been described above.