### PR TITLE
since the ast AnnAssign class can be value-less, avoid resolution fai…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/issues/144>`__.
 - Instantiation links with source an entire subclass incorrectly showed
   ``--*.help``.
+- Ensure AST-based parameter resolver handles value-less type annotations without error
+  `#148 <https://github.com/omni-us/jsonargparse/issues/148>`__.
 
 Changed
 ^^^^^^^

--- a/jsonargparse/parameter_resolvers.py
+++ b/jsonargparse/parameter_resolvers.py
@@ -322,7 +322,8 @@ class ParametersVisitor(LoggerProperty, ast.NodeVisitor):
                 self.generic_visit(node)
 
     def visit_AnnAssign(self, node):
-        self.visit_Assign(node)
+        if node.value is not None:
+            self.visit_Assign(node)
 
     def visit_Call(self, node):
         for key, value in self.find_values.items():

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -55,6 +55,14 @@ class ClassC(ClassB):
         """
         super().__init__(**kargs)
 
+class ClassN:
+    def __init__(self, kn1: int = 1, **kargs):
+        """
+        Args:
+            kn1: help for kn1
+        """
+        self.kn2: int  # verify (though questionable stylistically) that value-less AnnAssign doesn't break resolution
+
 class Param:
     p1: int = 2
 
@@ -282,6 +290,11 @@ class GetClassParametersTests(unittest.TestCase):
         assert_params(self, get_params(ClassC), ['kc1', 'pkb1', 'kb1', 'kb2', 'ka1'])
         with source_unavailable():
             assert_params(self, get_params(ClassC), ['kc1', 'pkb1', 'kb1', 'kb2', 'ka1', 'ka2'])
+
+    def test_get_params_class_with_valueless_init_ann(self):
+        assert_params(self, get_params(ClassN), ['kn1'])
+        with source_unavailable():
+            assert_params(self, get_params(ClassN), ['kn1'])
 
     def test_get_params_class_with_inheritance_parent_without_init(self):
         params = get_params(ClassD)


### PR DESCRIPTION
Thanks so much to everyone in the community (especially @mauvilsa !) for this immensely valuable package!

This PR fixes #147.

## What does this PR do?

According to [the current cpython abstract grammar definition](https://github.com/python/cpython/blob/d382f7ee0b98e4ab6ade9384268f25c06be462ad/Parser/Python.asdl#L29), the value of an ``ast.AnnAssign`` class can be ``None`` (also discussed in [PEP 526](https://peps.python.org/pep-0526/)) whether within methods or in the class body.  So though it's usually considered bad practice stylistically, since it's valid syntax, AST-based parameter resolution should handle this edge case I think. 

I've written a tiny one-line fix for this issue and added an associated test in the parameter-resolver test module.

In case it's relevant, an alternate approach to testing that I validated was to simply add a value-less annotation within the [``__init__`` method of ClassA](https://github.com/omni-us/jsonargparse/blob/c989d91b7764c6e6de86e4be097b4f2cff761499/jsonargparse_tests/test_parameter_resolvers.py#L15-L21) but I ultimately decided that isolating the test the way I've done in this PR might make more sense. 

- [X] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [X] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [X] Did you verify that new and existing **tests pass locally**?
- [X] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
