### PR TITLE
Fix mypy failing to find type hints #151.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in any moment.
 
 
+v4.12.1 (2022-07-25)
+--------------------
+
+Fixed
+^^^^^
+- Mypy fails to find jsonargparse type hints `#151
+  <https://github.com/omni-us/jsonargparse/issues/51>`__.
+
+
 v4.12.0 (2022-07-22)
 --------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ maintainer =
 [options.package_data]
 jsonargparse =
     *.pyi
+    py.typed
 
 
 [metadata]


### PR DESCRIPTION
Add mypy **py.typed** marker file. Resolves #151.
