### PR TITLE
Fix compute_fn not given init_args defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in any moment.
 
 
+v4.15.1 (2022-10-??)
+--------------------
+
+Fixed
+^^^^^
+- ``compute_fn`` of a argument link applied on parse not given subclass default
+  ``init_args`` when loading from config.
+
+
 v4.15.0 (2022-09-27)
 --------------------
 

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -174,7 +174,8 @@ class ActionConfigFile(Action, FilesCompleterMethod):
 
     @staticmethod
     def apply_config(parser, cfg, dest, value) -> None:
-        with _ActionSubCommands.not_single_subcommand(), previous_config_context(cfg):
+        from .link_arguments import skip_apply_links
+        with _ActionSubCommands.not_single_subcommand(), previous_config_context(cfg), skip_apply_links():
             kwargs = {'env': False, 'defaults': False, '_skip_check': True, '_fail_no_subcommand': False}
             try:
                 cfg_path: Optional[Path] = Path(value, mode=get_config_read_mode())


### PR DESCRIPTION
## What does this PR do?

Fix for a bug introduced in v4.15.0 where compute_fn would be given a subclass namespace without default values in init_args when loading from config.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
