### PR TITLE
Subclass --*.help not available for types in Union

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Fixed
 ^^^^^
 - ``compute_fn`` of a argument link applied on parse not given subclass default
   ``init_args`` when loading from config.
+- Subclass ``--*.help`` option not available when type is a ``Union`` mixed with
+  not subclass types.
 
 
 v4.15.0 (2022-09-27)

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -1,5 +1,6 @@
 """Collection of useful actions to define arguments."""
 
+import inspect
 import os
 import re
 import sys
@@ -322,7 +323,11 @@ class _ActionHelpClassPath(Action):
 
     def update_init_kwargs(self, kwargs):
         if getattr(self._baseclass, '__origin__', None) == Union:
-            self._basename = iter_to_set_str(c.__name__ for c in self._baseclass.__args__ if c != NoneType)
+            from .typehints import ActionTypeHint
+            self._basename = iter_to_set_str(
+                c.__name__ for c in self._baseclass.__args__
+                if ActionTypeHint.is_subclass_typehint(c)
+            )
         else:
             self._basename = self._baseclass.__name__
         kwargs.update({

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -158,7 +158,7 @@ class ActionTypeHint(Action):
         typehint = kwargs.pop('type')
         if args[0].startswith('--') and ActionTypeHint.supports_append(typehint):
             args = tuple(list(args)+[args[0]+'+'])
-        if ActionTypeHint.is_subclass_typehint(typehint):
+        if ActionTypeHint.is_subclass_typehint(typehint, all_subtypes=False):
             help_action = container.add_argument(args[0]+'.help', action=_ActionHelpClassPath(baseclass=typehint))
             if sub_add_kwargs:
                 help_action.sub_add_kwargs = sub_add_kwargs

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -170,8 +170,11 @@ def usage_and_exit_error_handler(parser: 'ArgumentParser', message: str) -> None
 
 
 def is_subclass(cls, class_or_tuple):
-    """Extension of issubclass that supports non-class argument."""
-    return inspect.isclass(cls) and issubclass(cls, class_or_tuple)
+    """Extension of issubclass that supports non-class arguments."""
+    try:
+        return inspect.isclass(cls) and issubclass(cls, class_or_tuple)
+    except TypeError:
+        return False
 
 
 def import_object(name: str):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -723,6 +723,21 @@ class TypeHintsTests(unittest.TestCase):
             self.assertEqual(cfg.data.init_args, Namespace(p1=2, p2='y', p3=True))
 
 
+    def test_class_type_subclass_in_union_help(self):
+        parser = ArgumentParser()
+        parser.add_argument('--op', type=Union[str, Mapping[str, int], Calendar])
+
+        out = StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit):
+            parser.parse_args(['--help'])
+        self.assertIn('Show the help for the given subclass of Calendar', out.getvalue())
+
+        out = StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit):
+            parser.parse_args([f'--op.help=TextCalendar'])
+        self.assertIn('--op.init_args.firstweekday', out.getvalue())
+
+
     def test_class_type_subclass_nested_help(self):
         class Class:
             def __init__(self, cal: Calendar, p1: int = 0):


### PR DESCRIPTION
## What does this PR do?

Fixed an issue where subclass --*.help option would not available when type is a Union mixed with not subclass types.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
