### PR TITLE
Fix override of Callable init_args without passing the class_path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Fixed
 - ``default_env`` not forwarded to subcommand parsers, causing environment
   variable names to not be shown in subcommand help `pytorch-lightning#12790
   <https://github.com/Lightning-AI/lightning/issues/12790>`__.
+- Cannot override Callable ``init_args`` without passing the ``class_path``
+  `#174 <https://github.com/omni-us/jsonargparse/issues/174>`__.
 
 
 v4.15.1 (2022-10-07)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -479,6 +479,24 @@ class TypeHintsTests(unittest.TestCase):
             self.assertRaises(ParserError, lambda: parser.parse_args([f'--callable={json.dumps(value)}']))
 
 
+    def test_callable_with_class_path_short_init_args(self):
+        class MyCallable:
+            def __init__(self, name: str):
+                self.name = name
+            def __call__(self):
+                return self.name
+
+        parser = ArgumentParser()
+        parser.add_argument('--call', type=Callable)
+
+        with mock_module(MyCallable) as module:
+            cfg = parser.parse_args([f'--call={module}.MyCallable', '--call.name=Bob'])
+            self.assertEqual(cfg.call.class_path, f'{module}.MyCallable')
+            self.assertEqual(cfg.call.init_args, Namespace(name='Bob'))
+            init = parser.instantiate_classes(cfg)
+            self.assertEqual(init.call(), 'Bob')
+
+
     def test_typed_Callable_with_function_path(self):
         def my_func_1(p: int) -> str:
             return str(p)


### PR DESCRIPTION
## What does this PR do?

Fixes #174

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
