### PR TITLE
Fix override of Union Callable init_args without class_path

### DIFF
--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -235,8 +235,12 @@ class ActionTypeHint(Action):
 
 
     @staticmethod
-    def is_callable_typehint(typehint):
+    def is_callable_typehint(typehint, all_subtypes=True):
         typehint_origin = get_typehint_origin(typehint)
+        if typehint_origin == Union:
+            subtypes = [a for a in typehint.__args__ if a != NoneType]
+            test = all if all_subtypes else any
+            return test(ActionTypeHint.is_callable_typehint(s) for s in subtypes)
         return typehint_origin in callable_origin_types or typehint in callable_origin_types
 
 
@@ -267,7 +271,7 @@ class ActionTypeHint(Action):
         typehint = typehint_from_action(action)
         if typehint and (
             ActionTypeHint.is_subclass_typehint(typehint, all_subtypes=False) or
-            ActionTypeHint.is_callable_typehint(typehint) or
+            ActionTypeHint.is_callable_typehint(typehint, all_subtypes=False) or
             ActionTypeHint.is_mapping_typehint(typehint)
         ):
             return action, arg_base, explicit_arg

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -497,6 +497,24 @@ class TypeHintsTests(unittest.TestCase):
             self.assertEqual(init.call(), 'Bob')
 
 
+    def test_union_callable_with_class_path_short_init_args(self):
+        class MyCallable:
+            def __init__(self, name: str):
+                self.name = name
+            def __call__(self):
+                return self.name
+
+        parser = ArgumentParser()
+        parser.add_argument('--call', type=Union[Callable, None])
+
+        with mock_module(MyCallable) as module:
+            cfg = parser.parse_args([f'--call={module}.MyCallable', '--call.name=Bob'])
+            self.assertEqual(cfg.call.class_path, f'{module}.MyCallable')
+            self.assertEqual(cfg.call.init_args, Namespace(name='Bob'))
+            init = parser.instantiate_classes(cfg)
+            self.assertEqual(init.call(), 'Bob')
+
+
     def test_typed_Callable_with_function_path(self):
         def my_func_1(p: int) -> str:
             return str(p)


### PR DESCRIPTION
## What does this PR do?

Fix #174 

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [n/a] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
