### PR TITLE
Fix some issues identified together related to type hints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ Fixed
 - Cannot override Callable ``init_args`` without passing the ``class_path``
   `#174 <https://github.com/omni-us/jsonargparse/issues/174>`__.
 - Positional subclass type incorrectly adds subclass help as positional.
+- Order of types in ``Union`` not being considered.
+- ``str`` type fails to parse values of the form ``^\w+: *``.
+- ``parse_object`` does not consider given namespace for previous ``class_path``
+  values.
 
 
 v4.15.1 (2022-10-07)

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -419,7 +419,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             if cfg_base:
                 cfg = self.merge_config(cfg_base, cfg)
 
-            cfg_obj = self._apply_actions(cfg_obj)
+            cfg_obj = self._apply_actions(cfg_obj, prev_cfg=cfg)
             cfg = self.merge_config(cfg_obj, cfg)
 
             parsed_cfg = self._parse_common(

--- a/jsonargparse/loaders_dumpers.py
+++ b/jsonargparse/loaders_dumpers.py
@@ -106,12 +106,15 @@ def get_loader_exceptions():
     return loader_exceptions[load_value_mode.get()]
 
 
-def load_value(value: str, **kwargs):
+def load_value(value: str, simple_types: bool = False, **kwargs):
     loader = loaders[load_value_mode.get()]
     if kwargs:
         params = set(list(inspect.signature(loader).parameters)[1:])
         kwargs = {k: v for k, v in kwargs.items() if k in params}
-    return loader(value, **kwargs)
+    loaded_value = loader(value, **kwargs)
+    if not simple_types and isinstance(loaded_value, (int, float, bool)):
+        loaded_value = value
+    return loaded_value
 
 
 dump_yaml_kwargs = {

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -124,7 +124,7 @@ def identity(value):
 NestedArg = namedtuple('NestedArg', 'key val')
 
 
-def parse_value_or_config(value: Any, enable_path: bool = True) -> Tuple[Any, Optional['Path']]:
+def parse_value_or_config(value: Any, enable_path: bool = True, simple_types: bool = False) -> Tuple[Any, Optional['Path']]:
     """Parses yaml/json config in a string or a path"""
     nested_arg: Union[bool, NestedArg] = False
     if isinstance(value, NestedArg):
@@ -138,9 +138,9 @@ def parse_value_or_config(value: Any, enable_path: bool = True) -> Tuple[Any, Op
             pass
         else:
             with change_to_path_dir(cfg_path):
-                value = load_value(cfg_path.get_content())
+                value = load_value(cfg_path.get_content(), simple_types=simple_types)
     if type(value) is str and value.strip() != '':
-        parsed_val = load_value(value)
+        parsed_val = load_value(value, simple_types=simple_types)
         if type(parsed_val) is not str:
             value = parsed_val
     if isinstance(value, dict) and cfg_path is not None:

--- a/jsonargparse_tests/test_cli.py
+++ b/jsonargparse_tests/test_cli.py
@@ -230,7 +230,6 @@ class CLITempDirTests(TempDirTestCase):
             def cmd_b(self):
                 print(self.b.a.p1)
 
-
         with mock_module(A, B) as module:
             a_yaml = {
                 'class_path': f'{module}.A',

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -2,10 +2,11 @@
 
 import os
 import unittest
+import unittest.mock
 import yaml
 from importlib.util import find_spec
 from typing import List
-from jsonargparse import ActionConfigFile, ArgumentParser, set_dumper, set_loader, ParserError
+from jsonargparse import ActionConfigFile, ArgumentParser, set_dumper, set_loader
 from jsonargparse.loaders_dumpers import loaders, load_value, load_value_context, yaml_dump
 
 
@@ -23,17 +24,6 @@ class LoadersTests(unittest.TestCase):
             cfg = parser.parse_args(['--list=[1,2,3]'])
             dump = parser.dump(cfg, format='yaml_custom')
             self.assertEqual(dump, '{list: [1, 2, 3]}\n')
-
-
-    def test_set_loader_safe_load_invalid_scientific_notation(self):
-        parser = ArgumentParser(error_handler=None)
-        parser.add_argument('--num', type=float)
-
-        with unittest.mock.patch.dict('jsonargparse.loaders_dumpers.loaders'):
-            set_loader('yaml', yaml.safe_load)
-            self.assertRaises(ParserError, lambda: parser.parse_args(['--num=1e-3']))
-
-        self.assertEqual(1e-3, parser.parse_args(['--num=1e-3']).num)
 
 
     def test_disable_implicit_mapping_values(self):

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -121,7 +121,6 @@ class SignaturesTests(unittest.TestCase):
         self.assertEqual('a', Class3(**cfg.as_dict())())
 
         self.assertRaises(ParserError, lambda: parser.parse_args([]))  # c3_a0 is required
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--c3_a0=0', '--c3_a7=["3", "3", 3.0]']))  # tuple[1] is int
 
         if docstring_parser_support:
             self.assertEqual('Class3 short description', parser.groups['Class3'].title)
@@ -448,10 +447,9 @@ class SignaturesTests(unittest.TestCase):
             def __init__(self, cal: Union[Calendar, bool] = lazy_instance(MyCalendar, param=1)):
                 self.cal = cal
 
-        parser = ArgumentParser(error_handler=None)
-        parser.add_class_arguments(Main, 'main')
-
-        with warnings.catch_warnings(record=True) as w:
+        with mock_module(MyCalendar), warnings.catch_warnings(record=True) as w:
+            parser = ArgumentParser(error_handler=None)
+            parser.add_class_arguments(Main, 'main')
             parser.parse_args(['--main.cal=Calendar'])
             self.assertIn("discarding init_args: {'param': 1}", str(w[0].message))
 


### PR DESCRIPTION
## What does this PR do?

As the title says.

- Order of types in `Union` not being considered.
- `str` type fails to parse values of the form `^\w+: *`.
- `parse_object` does not consider given namespace for previous `class_path` values.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
