### PR TITLE
Fix IPython AttributeError in parse_known_args

### DIFF
--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -224,7 +224,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
 
     def parse_known_args(self, args=None, namespace=None):
         """Raises NotImplementedError to dissuade its use, since typos in configs would go unnoticed."""
-        caller = inspect.getmodule(inspect.stack()[1][0]).__package__
+        caller_mod = inspect.getmodule(inspect.stack()[1][0])
+        caller = None if caller_mod is None else caller_mod.__package__
         if caller not in {'jsonargparse', 'argcomplete'}:
             raise NotImplementedError('parse_known_args not implemented to dissuade its use, since typos in configs would go unnoticed.')
 

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -1151,6 +1151,16 @@ class OtherTests(unittest.TestCase):
         parser = ArgumentParser()
         self.assertRaises(NotImplementedError, lambda: parser.parse_known_args([]))
 
+    def test_parse_known_args_without_caller_module(self):
+        """
+        Test case for corner case when calling parse_known_args in IPython.
+        The caller module will not exist. Test this is handled.
+        See https://github.com/omni-us/jsonargparse/pull/179
+        """
+        with unittest.mock.patch('inspect.getmodule') as mock_getmodule:
+            mock_getmodule.return_value = None
+            parser = ArgumentParser()
+            self.assertRaises(NotImplementedError, lambda: parser.parse_known_args([]))
 
     def test_parse_args_invalid_args(self):
         parser = ArgumentParser(error_handler=None)


### PR DESCRIPTION
## What does this PR do?

This is a minor fix. When running `parser.parse_known_args` in IPython, the inspect logic raises an AttributeError. This obfuscates the expected NotImplemented error message. Here is a MWE:

Step 1: Start IPython:

Step 2: Paste in:

```python
    import jsonargparse
    parser = jsonargparse.ArgumentParser()
    parser.add_argument('--foo')
    parser.parse_known_args(args=[])
```

Before the patch this causes `AttributeError: 'NoneType' object has no attribute '__package__'`. 

After this patch it correctly raises `NotImplementedError: parse_known_args not implemented to dissuade its use, since typos in configs would go unnoticed.`.

Now, I have opinions about being not being allowed to use `parse_known_args`. I'm not afraid of the potential shoegun, and often I need the functionality, but I'll save that for a different thread, this change should be fairly uncontroversial.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [na] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [na] Did you verify that new and existing **tests pass locally**?
- [na] Did you make sure that all changes preserve **backward compatibility**?
- [na] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
