### PR TITLE
Remove NotImplementedError from parse_known_args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Fixed
 - Fail to import on Python 3.7 when typing_extensions not installed `#178
   <https://github.com/omni-us/jsonargparse/issues/178>`__.
 
+Changed
+^^^^^^^
+- ``parse_known_args`` no longer raises a ``NotImplementedError``.
+   `#180 <https://github.com/omni-us/jsonargparse/issues/180>`__.
+
 
 v4.15.2 (2022-10-20)
 --------------------

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -223,10 +223,29 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
     ## Parsing methods ##
 
     def parse_known_args(self, args=None, namespace=None):
-        """Raises NotImplementedError to dissuade its use, since typos in configs would go unnoticed."""
+        """Parses command line argument strings, ignoring unknown entries.
+
+        All the arguments from `argparse.ArgumentParser.parse_known_args
+        <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_known_args>`_
+        are supported. Additionally it accepts:
+
+        Args:
+            args: List of arguments to parse or None to use sys.argv.
+            env: Whether to merge with the parsed environment, None to use parser's default.
+            defaults: Whether to merge with the parser's defaults.
+            with_meta: Whether to include metadata in config object, None to use parser's default.
+
+        Returns:
+            A config object with all parsed values.
+
+        Raises:
+            ParserError: If there is a parsing error and error_handler=None.
+
+        Warning:
+            Using this means that typos in configurations will go unnoticed!
+            It is strongly recommended to use :func:`.parse_args` instead.
+        """
         caller = inspect.getmodule(inspect.stack()[1][0]).__package__
-        if caller not in {'jsonargparse', 'argcomplete'}:
-            raise NotImplementedError('parse_known_args not implemented to dissuade its use, since typos in configs would go unnoticed.')
 
         if args is None:
             args = sys.argv[1:]

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -1149,7 +1149,7 @@ class OtherTests(unittest.TestCase):
 
     def test_parse_known_args(self):
         parser = ArgumentParser()
-        self.assertRaises(NotImplementedError, lambda: parser.parse_known_args([]))
+        parser.parse_known_args([])
 
 
     def test_parse_args_invalid_args(self):


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Addresses #180 using option 5, which simply removes the NotImplementedError.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [?] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

Not sure if this requires more in-depth tests as it is covered via `parse_args`. Because I'm not sure if this will be accepted or not, I'll punt on that for now. I did change the existing test to just call it and check it no longer raises any error.