### PR TITLE
Fix Namespace method names and key clash problem

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,8 @@ Fixed
 - ``init_args`` not discarded for nested subclasses provided through command
   line `pytorch-lightning#15796
   <https://github.com/Lightning-AI/lightning/issues/15796>`__.
+- Unable to set/get values in ``Namespace`` when key is the same as a method
+  name.
 
 Changed
 ^^^^^^^


### PR DESCRIPTION
## What does this PR do?

With this change now it is possible to set/get values in a namespace having the same name as a method of the Namespace class.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
