### PR TITLE
Fix for list type with empty list default causing failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Added
 ^^^^^
 - ``CLI`` now exposes the ``fail_untyped`` parameter.
 
+Fixed
+^^^^^
+- List type with empty list default causes failure `PyLaia#48
+  <https://github.com/jpuigcerver/PyLaia/issues/48>`__.
+
 
 v4.18.0 (2022-11-29)
 --------------------

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -656,8 +656,10 @@ def adapt_typehints(val, typehint, serialize=False, instantiate_classes=False, p
         elif not isinstance(val, list):
             raise_unexpected_value(f'Expected a {typehint_origin}', val)
         if subtypehints is not None:
+            adapt_kwargs_n = adapt_kwargs
             for n, v in enumerate(val):
-                adapt_kwargs_n = {**adapt_kwargs, 'prev_val': prev_val[n]} if isinstance(prev_val, list) else adapt_kwargs
+                if isinstance(prev_val, list) and len(prev_val) == len(val):
+                    adapt_kwargs_n = {**adapt_kwargs, 'prev_val': prev_val[n]}
                 val[n] = adapt_typehints(v, subtypehints[0], **adapt_kwargs_n)
 
     # Dict, Mapping

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -340,6 +340,16 @@ class TypeHintsTests(unittest.TestCase):
             self.assertIn('Replacing list value "[1, 2]" with "3"', str(w[0].message))
 
 
+    def test_list_append_default_empty(self):
+        parser = ArgumentParser()
+        parser.add_argument('--list', type=List[str], default=[])
+        self.assertEqual([], parser.get_defaults().list)
+        self.assertEqual(['a'], parser.parse_args(['--list=[a]']).list)
+        self.assertEqual([], parser.get_defaults().list)
+        self.assertEqual(['b', 'c'], parser.parse_args(['--list+=[b, c]']).list)
+        self.assertEqual([], parser.get_defaults().list)
+
+
     def test_list_append_config(self):
         parser = ArgumentParser(error_handler=None)
         parser.add_argument('--cfg', action=ActionConfigFile)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/jpuigcerver/PyLaia/issues/48

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
