### PR TITLE
Fix incorrectly considering pure dataclass instance default as a subclass type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Fixed
 ^^^^^
 - List type with empty list default causes failure `PyLaia#48
   <https://github.com/jpuigcerver/PyLaia/issues/48>`__.
+- Pure dataclass instance default being considered as a subclass type.
 
 
 v4.18.0 (2022-11-29)

--- a/jsonargparse/parameter_resolvers.py
+++ b/jsonargparse/parameter_resolvers.py
@@ -294,6 +294,9 @@ def get_kwargs_pop_or_get_parameter(node, component, parent, doc_params, log_deb
 
 
 def is_param_subclass_instance_default(param: ParamData) -> bool:
+    from .signatures import is_pure_dataclass
+    if is_pure_dataclass(type(param.default)):
+        return False
     from .typehints import ActionTypeHint, get_subclass_types
     class_types = get_subclass_types(param.annotation)
     return (


### PR DESCRIPTION
## What does this PR do?

Fix regression caused by https://github.com/omni-us/jsonargparse/commit/8df46b1044bcad10f6d3137a784519b6abce7998.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
