### PR TITLE
Link arguments error improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ Added
   Base64.
 - Support getting the import path of variables in modules, e.g.
   ``random.randint``.
+- Specific error messages for when an argument link uses as source the target of
+  a previous parse link and vice versa `#208
+  <https://github.com/omni-us/jsonargparse/issues/208>`__.
 
 Fixed
 ^^^^^
@@ -31,6 +34,12 @@ Fixed
 - Discard ``init_args`` after ``class_path`` change causes error `#205
   <https://github.com/omni-us/jsonargparse/issues/205>`__.
 - Issues reported by CodeQL.
+
+Changed
+^^^^^^^
+- Clearer error message for when an argument link targets a subclass and the
+  target key does not have ``init_args`` `pytorch-lightning#16032
+  <https://github.com/Lightning-AI/lightning/issues/16032>`__.
 
 
 v4.18.0 (2022-11-29)

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -22,6 +22,28 @@ from jsonargparse_tests.base import TempDirTestCase, mock_module
 
 class LinkArgumentsTests(unittest.TestCase):
 
+    def test_link_arguments_previous_target_as_source_error(self):
+        parser = ArgumentParser()
+        parser.add_argument('--a')
+        parser.add_argument('--b')
+        parser.add_argument('--c')
+        parser.link_arguments('a', 'b')
+        with self.assertRaises(ValueError) as ctx:
+            parser.link_arguments('b', 'c')
+        self.assertIn('Source "b" not allowed', str(ctx.exception))
+
+
+    def test_link_arguments_previous_source_as_target_error(self):
+        parser = ArgumentParser()
+        parser.add_argument('--a')
+        parser.add_argument('--b')
+        parser.add_argument('--c')
+        parser.link_arguments('b', 'c')
+        with self.assertRaises(ValueError) as ctx:
+            parser.link_arguments('a', 'b')
+        self.assertIn('Target "b" not allowed', str(ctx.exception))
+
+
     def test_link_arguments_on_parse_compute_fn_single_arguments(self):
         parser = ArgumentParser(error_handler=None)
         parser.add_argument('--a.v1', default=2)
@@ -339,8 +361,9 @@ class LinkArgumentsTests(unittest.TestCase):
 
         # Source must be subclass action or class group
         parser = make_parser_2()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as ctx:
             parser.link_arguments('a.b.c', 'b.b3', apply_on='instantiate')
+        self.assertIn('Target key expected to start with "b.init_args."', str(ctx.exception))
 
 
     def test_link_arguments_on_instantiate_no_compute_no_target_instantiate(self):


### PR DESCRIPTION
## What does this PR do?

- Added specific error message for when an argument link uses as source the target of a previous link and vice versa (#208).
- Clearer error message for when an argument link targets a subclass and the target key does not have init_args (pytorch-lightning#16032).

Fixes https://github.com/Lightning-AI/lightning/issues/16032

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
