### PR TITLE
Several improvements to path types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Added
   a previous parse link and vice versa `#208
   <https://github.com/omni-us/jsonargparse/issues/208>`__.
 - New resolver that identifies parameter types from stub files ``*.pyi``.
+- Support for relative paths within remote fsspec/url config files.
+- New context manager methods for path types: ``open`` and
+  ``relative_path_context``.
 
 Fixed
 ^^^^^
@@ -43,6 +46,7 @@ Changed
   target key does not have ``init_args`` `pytorch-lightning#16032
   <https://github.com/Lightning-AI/lightning/issues/16032>`__.
 - The ``signatures`` extras now installs the ``typeshed-client`` package.
+- ``validators`` package is no longer a dependency.
 
 
 v4.18.0 (2022-11-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Added
 - Support for relative paths within remote fsspec/url config files.
 - New context manager methods for path types: ``open`` and
   ``relative_path_context``.
+- Path types now implement the ``os.PathLike`` protocol.
+- New path mode ``cc`` to not require the parent directory to exists but that it
+  can be created.
 
 Fixed
 ^^^^^
@@ -39,6 +42,7 @@ Fixed
   <https://github.com/omni-us/jsonargparse/issues/205>`__.
 - ``fail_untyped=False`` not propagated to subclass ``--*.help`` actions.
 - Issues reported by CodeQL.
+- Incorrect value when ``Path`` is cast to ``str`` and ``rel_path`` was changed.
 
 Changed
 ^^^^^^^
@@ -47,6 +51,7 @@ Changed
   <https://github.com/Lightning-AI/lightning/issues/16032>`__.
 - The ``signatures`` extras now installs the ``typeshed-client`` package.
 - ``validators`` package is no longer a dependency.
+- Path types are no longer a subclass of ``str``.
 
 
 v4.18.0 (2022-11-29)

--- a/README.rst
+++ b/README.rst
@@ -653,7 +653,7 @@ like the following would work:
 
     Relative paths inside a remote path are parsed as remote. For example, for a
     relative path ``model/state_dict.pt`` found inside
-    ``s3://bucket/config.yaml``, its parsed full path becomes
+    ``s3://bucket/config.yaml``, its parsed absolute path becomes
     ``s3://bucket/model/state_dict.pt``.
 
 

--- a/README.rst
+++ b/README.rst
@@ -619,21 +619,20 @@ Parsing URLs
 
 The :func:`.path_type` function also supports URLs which after parsing, the
 :py:meth:`.Path.get_content` method can be used to perform a GET request to the
-corresponding URL and retrieve its content. For this to work the *validators*
-and *requests* python packages are required. Alternatively, :func:`.path_type`
-can also be used for `fsspec <https://filesystem-spec.readthedocs.io>`__
-supported file systems. The respective optional package(s) will be installed
-along with jsonargparse if installed with the ``urls`` or ``fsspec`` extras
-require as explained in section :ref:`installation`.
+corresponding URL and retrieve its content. For this to work the *requests*
+python package is required. Alternatively, :func:`.path_type` can also be used
+for `fsspec <https://filesystem-spec.readthedocs.io>`__ supported file systems.
+The respective optional package(s) will be installed along with jsonargparse if
+installed with the ``urls`` or ``fsspec`` extras require as explained in section
+:ref:`installation`.
 
 The ``'u'`` flag is used to parse URLs using requests and the flag ``'s'`` to
 parse fsspec file systems. For example if it is desired that an argument can be
 either a readable file or URL, the type would be created as ``Path_fur =
-path_type('fur')``. If the value appears to be a URL according to
-:func:`validators.url.url` then a HEAD request would be triggered to check if it
-is accessible. To get the content of the parsed path, without needing to care if
-it is a local file or a URL, the :py:meth:`.Path.get_content` method Scan be
-used.
+path_type('fur')``. If the value appears to be a URL, a HEAD request would be
+triggered to check if it is accessible. To get the content of the parsed path,
+without needing to care if it is a local file or a URL, the
+:py:meth:`.Path.get_content` method Scan be used.
 
 If you import ``from jsonargparse import set_config_read_mode`` and then run
 ``set_config_read_mode(urls_enabled=True)`` or
@@ -649,6 +648,13 @@ like the following would work:
 .. code-block:: bash
 
     my_tool.py --config http://example.com/config.yaml
+
+.. note::
+
+    Relative paths inside a remote path are parsed as remote. For example, for a
+    relative path ``model/state_dict.pt`` found inside
+    ``s3://bucket/config.yaml``, its parsed full path becomes
+    ``s3://bucket/model/state_dict.pt``.
 
 
 .. _boolean-arguments:

--- a/jsonargparse/optionals.py
+++ b/jsonargparse/optionals.py
@@ -18,7 +18,7 @@ typing_extensions_support = find_spec('typing_extensions') is not None
 typeshed_client_support = find_spec('typeshed_client') is not None
 jsonschema_support = find_spec('jsonschema') is not None
 jsonnet_support = find_spec('_jsonnet') is not None
-url_support = False if any(find_spec(x) is None for x in ['validators', 'requests']) else True
+url_support = find_spec('requests') is not None
 docstring_parser_support = find_spec('docstring_parser') is not None
 argcomplete_support = find_spec('argcomplete') is not None
 fsspec_support = find_spec('fsspec') is not None
@@ -97,12 +97,6 @@ def import_jsonnet(importer):
     return _jsonnet
 
 
-def import_url_validator(importer):
-    with missing_package_raise('validators', importer):
-        from validators.url import url as url_validator
-    return url_validator
-
-
 def import_requests(importer):
     with missing_package_raise('requests', importer):
         import requests
@@ -150,15 +144,14 @@ def set_config_read_mode(
         fsspec_enabled: Whether to read config files from fsspec supported file systems.
     """
     imports = {
-        'u': [import_url_validator, import_requests],
-        's': [import_fsspec],
+        'u': import_requests,
+        's': import_fsspec,
     }
 
     def update_mode(flag, enabled):
         global _config_read_mode
         if enabled:
-            for import_func in imports[flag]:
-                import_func('set_config_read_mode')
+            imports[flag]('set_config_read_mode')
             if flag not in _config_read_mode:
                 _config_read_mode = _config_read_mode.replace('f', 'f'+flag)
         else:

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -1082,7 +1082,7 @@ def typehint_from_action(action_or_typehint):
 
 
 def type_to_str(obj):
-    if obj in {bool, tuple} or is_subclass(obj, (int, float, str, Enum)):
+    if obj in {bool, tuple} or is_subclass(obj, (int, float, str, Path, Enum)):
         return obj.__name__
     return re.sub(r'[A-Za-z0-9_<>.]+\.', '', str(obj)).replace('NoneType', 'null')
 

--- a/jsonargparse/typing.py
+++ b/jsonargparse/typing.py
@@ -226,10 +226,10 @@ def path_type(
         _skip_check = skip_check
         _type = str
 
-        def __init__(self, v):
-            super().__init__(v, mode=self._mode, skip_check=self._skip_check)
+        def __init__(self, v, **k):
+            super().__init__(v, mode=self._mode, skip_check=self._skip_check, **k)
 
-    restricted_type = type(name, (PathType, str), {'__doc__': docstring})
+    restricted_type = type(name, (PathType,), {'__doc__': docstring})
     add_type(restricted_type, register_key, type_check=_is_path_type)
 
     return restricted_type
@@ -350,11 +350,11 @@ NotEmptyStr = restricted_string_type('NotEmptyStr', r'^.*[^ ].*$',
 Email       = restricted_string_type('Email', r'^[^@ ]+@[^@ ]+\.[^@ ]+$',
                                      docstring=r'str restricted to the email pattern ^[^@ ]+@[^@ ]+\.[^@ ]+$')
 
-Path_fr = path_type('fr', docstring='str pointing to a file that exists and is readable')
-Path_fc = path_type('fc', docstring='str pointing to a file that can be created if it does not exist')
-Path_dw = path_type('dw', docstring='str pointing to a directory that exists and is writeable')
-Path_dc = path_type('dc', docstring='str pointing to a directory that can be created if it does not exist')
-Path_drw = path_type('drw', docstring='str pointing to a directory that exists and is readable and writeable')
+Path_fr = path_type('fr', docstring='path to a file that exists and is readable')
+Path_fc = path_type('fc', docstring='path to a file that can be created if it does not exist')
+Path_dw = path_type('dw', docstring='path to a directory that exists and is writeable')
+Path_dc = path_type('dc', docstring='path to a directory that can be created if it does not exist')
+Path_drw = path_type('drw', docstring='path to a directory that exists and is readable and writeable')
 
 register_type(os.PathLike, str, str)
 register_type(complex)

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -593,7 +593,7 @@ class AdvancedFeaturesTests(unittest.TestCase):
         self.assertEqual(yaml.safe_load(out.getvalue()), {'o': 1})
 
 
-    @unittest.skipIf(not (url_support and responses_available), 'validators, requests and responses packages are required')
+    @unittest.skipIf(not (url_support and responses_available), 'requests and responses packages are required')
     @responses_activate
     def test_urls(self):
         set_config_read_mode(urls_enabled=True)

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -133,7 +133,7 @@ class DeprecatedTests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: ActionOperators(expr=[('<', 5), ('>=', 10)], join='xor'))
 
 
-    @unittest.skipIf(not url_support, 'validators and requests packages are required')
+    @unittest.skipIf(not url_support, 'requests package is required')
     def test_url_support_true(self):
         self.assertEqual('fr', get_config_read_mode())
         with catch_warnings(record=True) as w:
@@ -144,7 +144,7 @@ class DeprecatedTests(unittest.TestCase):
         self.assertEqual('fr', get_config_read_mode())
 
 
-    @unittest.skipIf(url_support, 'validators and requests packages should not be installed')
+    @unittest.skipIf(url_support, 'requests package should not be installed')
     def test_url_support_false(self):
         self.assertEqual('fr', get_config_read_mode())
         with catch_warnings(record=True) as w:

--- a/jsonargparse_tests/test_optionals.py
+++ b/jsonargparse_tests/test_optionals.py
@@ -16,7 +16,6 @@ from jsonargparse.optionals import (
     import_jsonschema,
     import_requests,
     import_ruyaml,
-    import_url_validator,
     jsonnet_support,
     jsonschema_support,
     ruyaml_support,
@@ -55,18 +54,13 @@ class JsonnetSupportTests(unittest.TestCase):
 
 class UrlSupportTests(unittest.TestCase):
 
-    @unittest.skipIf(not url_support, 'validators and requests packages are required')
+    @unittest.skipIf(not url_support, 'requests package is required')
     def test_url_support_true(self):
-        import_url_validator('test_url_support_true')
         import_requests('test_url_support_true')
 
 
-    @unittest.skipIf(url_support, 'validators and requests packages should not be installed')
+    @unittest.skipIf(url_support, 'requests package should not be installed')
     def test_url_support_false(self):
-        if find_spec('validators') is None:
-            with self.assertRaises(ImportError) as context:
-                import_url_validator('test_url_support_false')
-                self.assertIn('test_url_support_false', context.msg)
         if find_spec('requests') is None:
             with self.assertRaises(ImportError) as context:
                 import_requests('test_url_support_false')
@@ -159,7 +153,7 @@ class ConfigReadModeTests(unittest.TestCase):
         set_config_read_mode()
 
 
-    @unittest.skipIf(not url_support, 'validators and requests packages are required')
+    @unittest.skipIf(not url_support, 'requests package is required')
     def test_url_support_true(self):
         self.assertEqual('fr', get_config_read_mode())
         set_config_read_mode(urls_enabled=True)
@@ -168,7 +162,7 @@ class ConfigReadModeTests(unittest.TestCase):
         self.assertEqual('fr', get_config_read_mode())
 
 
-    @unittest.skipIf(url_support, 'validators and requests packages should not be installed')
+    @unittest.skipIf(url_support, 'request package should not be installed')
     def test_url_support_false(self):
         self.assertEqual('fr', get_config_read_mode())
         with self.assertRaises(ImportError):

--- a/jsonargparse_tests/test_typing.py
+++ b/jsonargparse_tests/test_typing.py
@@ -13,6 +13,7 @@ from jsonargparse.typing import (
     NonNegativeFloat,
     NonNegativeInt,
     OpenUnitInterval,
+    Path_fc,
     Path_fr,
     PositiveFloat,
     PositiveInt,
@@ -173,6 +174,11 @@ class PathTypeTests(TempDirTestCase):
         self.assertEqual(path, self.file_fr)
         self.assertEqual(path(), os.path.realpath(self.file_fr))
         self.assertRaises(TypeError, lambda: Path_fr('does_not_exist'))
+
+
+    def test_Path_fc_with_kwargs(self):
+        path = Path_fc('some-file.txt', cwd=self.tmpdir)
+        self.assertEqual(path(), os.path.join(self.tmpdir, 'some-file.txt'))
 
 
     def test_already_registered(self):

--- a/jsonargparse_tests/test_typing.py
+++ b/jsonargparse_tests/test_typing.py
@@ -17,7 +17,6 @@ from jsonargparse.typing import (
     Path_fr,
     PositiveFloat,
     PositiveInt,
-    RegisteredType,
     get_registered_type,
     path_type,
     register_type,
@@ -25,7 +24,7 @@ from jsonargparse.typing import (
     restricted_number_type,
     restricted_string_type,
 )
-from jsonargparse.util import import_object, object_path_serializer
+from jsonargparse.util import object_path_serializer
 from jsonargparse_tests.base import TempDirTestCase, mock_module
 
 
@@ -204,15 +203,9 @@ class PathTypeTests(TempDirTestCase):
 class OtherTests(unittest.TestCase):
 
     def test_pickle_module_types(self):
-        for import_path in [x for x in registered_types.keys() if isinstance(x, str)]:
-            get_registered_type(import_object(import_path))
-        for otype in registered_types.values():
-            if isinstance(otype, RegisteredType) or hasattr(__import__('jsonargparse.typing'), otype.__name__):
-                if isinstance(otype, RegisteredType):
-                    otype = otype.type_class
-                with self.subTest(str(otype)):
-                    utype = pickle.loads(pickle.dumps(otype))
-                    self.assertEqual(otype, utype)
+        for type_class in registered_types.values():
+            with self.subTest(str(type_class)):
+                self.assertEqual(type_class, pickle.loads(pickle.dumps(type_class)))
 
 
     def test_name_clash(self):
@@ -293,8 +286,6 @@ class OtherTests(unittest.TestCase):
         self.assertEqual(cfg.elems.elems, [1, 2, 3])
         dump = parser.dump(cfg, format='json')
         self.assertEqual(dump, '{"elems":[1,2,3]}')
-
-        del registered_types[Elems]
 
 
 if __name__ == '__main__':

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -72,11 +72,31 @@ class PathTests(TempDirTestCase):
         self.assertEqual(path1.rel_path, path2.rel_path)
         self.assertEqual(path1.is_url, path2.is_url)
         self.assertRaises(TypeError, lambda: Path(True))
+        self.assertRaises(ValueError, lambda: Path(self.file_rw, '-'))
+        self.assertRaises(ValueError, lambda: Path(self.file_rw, 'frr'))
 
 
     def test_cwd(self):
         path = Path('file_rx', mode='fr', cwd=os.path.join(self.tmpdir, 'dir_x'))
         self.assertEqual(path.cwd, Path('file_rx', mode='fr', cwd=path.cwd).cwd)
+
+
+    def test_empty_mode(self):
+        path = Path('does_not_exist', '')
+        self.assertEqual(path(), os.path.join(self.tmpdir, 'does_not_exist'))
+
+
+    def test_pathlike(self):
+        path = Path(self.file_rw)
+        self.assertEqual(os.fspath(path), os.path.join(self.tmpdir, self.file_rw))
+        self.assertEqual(os.path.dirname(path), self.tmpdir)
+
+
+    def test_equality_operator(self):
+        path1 = Path(self.file_rw)
+        path2 = Path(os.path.join(self.tmpdir, self.file_rw))
+        self.assertEqual(path1, path2)
+        self.assertNotEqual(Path('123', 'fc'), 123)
 
 
     def test_file_access_mode(self):
@@ -112,11 +132,13 @@ class PathTests(TempDirTestCase):
     def test_create_mode(self):
         Path(self.file_rw, 'fcrw')
         Path(os.path.join(self.tmpdir, 'file_c'), 'fc')
+        Path(os.path.join(self.tmpdir, 'not_existing_dir', 'file_c'), 'fcc')
         Path(self.dir_rwx, 'dcrwx')
         Path(os.path.join(self.tmpdir, 'dir_c'), 'dc')
         if is_posix:
             self.assertRaises(TypeError, lambda: Path(os.path.join(self.dir_rx, 'file_c'), 'fc'))
             self.assertRaises(TypeError, lambda: Path(os.path.join(self.dir_rx, 'dir_c'), 'dc'))
+            self.assertRaises(TypeError, lambda: Path(os.path.join(self.dir_rx, 'not_existing_dir', 'file_c'), 'fcc'))
         self.assertRaises(TypeError, lambda: Path(self.file_rw, 'dc'))
         self.assertRaises(TypeError, lambda: Path(self.dir_rwx, 'fc'))
         self.assertRaises(TypeError, lambda: Path(os.path.join(self.dir_rwx, 'ne', 'file_c'), 'fc'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ jsonnet =
     jsonnet>=0.13.0; os_name == 'posix'
     jsonnet-binary>=0.17.0; os_name != 'posix'
 urls =
-    validators>=0.14.2
     requests>=2.18.4
 fsspec =
     fsspec>=0.8.4


### PR DESCRIPTION
## What does this PR do?

Adds several new features for path types:
- Relative paths within remote fsspec/url config files.
- New context manager methods: `open` and `relative_path_context`.
- Implements the `os.PathLike` protocol.
- New path mode ``cc`` to not require the parent directory to exists but that it can be created.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
