### PR TITLE
Diverse fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - run:
@@ -16,7 +16,7 @@ jobs:
             - ./dist/*.tar.gz
   test-py38: &test-py38
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - attach_workspace:
           at: .
@@ -34,29 +34,29 @@ jobs:
           root: .
           paths:
             - ./coverage_*.xml
-  #test-py311:
-  #  <<: *test-py38
-  #  docker:
-  #    - image: circleci/python:3.11
+  test-py311:
+    <<: *test-py38
+    docker:
+      - image: cimg/python:3.11
   test-py310:
     <<: *test-py38
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
   test-py39:
     <<: *test-py38
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
   test-py37:
     <<: *test-py38
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
   test-py36:
     <<: *test-py38
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
   codecov:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - attach_workspace:
@@ -99,8 +99,8 @@ workflows:
           <<: *buildreq
           requires:
             - build
-      #- test-py311:
-      #    <<: *testreq
+      - test-py311:
+          <<: *testreq
       - test-py310:
           <<: *testreq
       - test-py39:
@@ -112,7 +112,7 @@ workflows:
       - codecov:
           <<: *testreq
           requires:
-            #- test-py311
+            - test-py311
             - test-py310
             - test-py39
             - test-py38

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,5 +1,9 @@
 name: code-checks
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   mypy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   unittest:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Fixed
 - Incorrect value when ``Path`` is cast to ``str`` and ``rel_path`` was changed.
 - Argument links with target a subclass mixed with other types not working `#208
   <https://github.com/omni-us/jsonargparse/issues/208>`__.
+- Failures when using a sequence type and the default is a tuple.
 
 Changed
 ^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -60,15 +60,6 @@ Features
 - Support for command line tab argument completion using `argcomplete
   <https://pypi.org/project/argcomplete/>`__.
 
-- Configuration values are overridden based on the following precedence.
-
-  - **Parsing command line:** command line arguments (might include config
-    files) > environment variables > default config files > defaults.
-  - **Parsing files:** config file > environment variables > default config
-    files > defaults.
-  - **Parsing environment:** environment variables > default config files >
-    defaults.
-
 
 .. _installation:
 
@@ -328,6 +319,29 @@ shown above you would observe:
 If the parsing fails the standard behavior is that the usage is printed and the
 program is terminated. Alternatively you can initialize the parser with
 ``error_handler=None`` in which case a :class:`.ParserError` is raised.
+
+
+Override order
+--------------
+
+Final parsed values depend on different sources, namely: source code, command
+line arguments, :ref:`configuration-files` and :ref:`environment-variables`.
+Values are overridden based on the following precedence:
+
+1. Defaults defined in the source code.
+2. Existing default config files in the order defined in
+   ``default_config_files``, e.g. ``~/.config/myapp.yaml``.
+3. Full config environment variable, e.g. ``APP_CONFIG``.
+4. Individual key environment variables, e.g. ``APP_OPT1``.
+5. Command line arguments in order left to right (might include config files).
+
+Depending on the parse method used (see :class:`.ArgumentParser`) and how the
+parser was built, some of the options above might not apply. Parsing of
+environment variables must be explicitly enabled, except if using
+:py:meth:`.ArgumentParser.parse_env`. If the parser does not have an
+:class:`.ActionConfigFile` argument, then there is no parsing of a full config
+environment variable or a way to provide a config file from command line.
+
 
 Capturing parsers
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -530,9 +530,6 @@ that exists and is readable, the following could be done:
 
 .. testsetup:: paths
 
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
@@ -590,9 +587,6 @@ string for reading the list from stdin. Example:
 
 .. testsetup:: path_list
 
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
@@ -757,7 +751,6 @@ can be achieved by adding ``+`` as suffix to the argument key, for example:
 
 .. testsetup:: append
 
-    from typing import List
     parser = ArgumentParser()
 
 .. doctest:: append
@@ -827,7 +820,6 @@ option is the import path of a callable object, for example:
 
 .. testsetup:: callable
 
-    from typing import Callable, Iterable
     parser = ArgumentParser()
 
 .. testcode:: callable
@@ -1080,9 +1072,6 @@ the following would be observed:
 
 .. testsetup:: config
 
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
@@ -1405,7 +1394,6 @@ Take for example the following parsing and instantiation:
 
 .. testsetup:: unresolved
 
-    import jsonargparse_tests
     sys.argv = ['', '--myclass=MyClass']
 
     class MyClass:
@@ -1466,7 +1454,6 @@ unrelated to these variables.
 
 .. testsetup:: ast_resolver
 
-    from typing import Callable
     class BaseClass: pass
     class SomeClass:
         def __init__(self, **kwargs):
@@ -1679,9 +1666,6 @@ Then in python:
 
 .. testsetup:: subclasses
 
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
@@ -1789,10 +1773,6 @@ debug.
 Since there are some legitimate use cases for class instances in defaults, they
 are supported with a particular behavior and recommendations. An example is:
 
-.. testsetup:: instance_default
-
-    from calendar import Calendar
-
 .. testcode:: instance_default
 
     class MyClass:
@@ -1849,10 +1829,6 @@ corresponding yaml structure.
 
 .. testsetup:: final_classes
 
-    import os
-    import shutil
-    import tempfile
-    from calendar import Calendar
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
@@ -1978,15 +1954,11 @@ Take for example a yaml file as:
     client:
       url: http://${server.host}:${server.port}/
     """
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)
     with open('example.yaml', 'w') as f:
         f.write(example)
-    from dataclasses import dataclass
 
 .. testcleanup:: omegaconf
 
@@ -2046,7 +2018,6 @@ command line arguments, that is:
 
 .. testsetup:: env
 
-    import os
     os.environ['APP_LEV1__OPT1'] = 'from env 1'
     os.environ['APP_LEV1__OPT2'] = 'from env 2'
 
@@ -2203,9 +2174,6 @@ config files to be in jsonnet format instead. Example:
 
 .. testsetup:: jsonnet
 
-    import os
-    import shutil
-    import tempfile
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix='_jsonargparse_doctest_')
     os.chdir(tmpdir)

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -230,7 +230,7 @@ class _ActionPrintConfig(Action):
             metavar='\b[=flags]',
             help=(
                 'Print the configuration after applying all other arguments and exit. The optional '
-                'flags are one or more keywords separated by comma which modify the output. The '
+                'flags customizes the output and are one or more keywords separated by comma. The '
                 'supported flags are: comments, skip_default, skip_null.'
             ),
         )

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -676,7 +676,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             **kwargs: All options that `argparse.ArgumentParser.add_subparsers` accepts.
         """
         if 'description' not in kwargs:
-            kwargs['description'] = 'For more details of each subcommand add it as argument followed by --help.'
+            kwargs['description'] = 'For more details of each subcommand, add it as an argument followed by --help.'
         with formatter_context(self):
             subcommands: _ActionSubCommands = super().add_subparsers(dest=dest, **kwargs)  # type: ignore
         if required:

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -537,7 +537,7 @@ def raise_unexpected_value(message: str, val: Any = inspect._empty, exception: O
 
 
 def raise_union_unexpected_value(uniontype, val: Any, exceptions: List[Exception]) -> NoReturn:
-    errors = indent_text('- '.join(str(e) for e in [''] + exceptions))
+    errors = indent_text('- ' + '\n- '.join(map(str, exceptions)))
     errors = errors.replace(f'. Got value: {val}', '').replace(f' {val} ', ' ')
     subtypes = uniontype.__args__
     raise ValueError(
@@ -670,6 +670,8 @@ def adapt_typehints(val, typehint, serialize=False, instantiate_classes=False, p
             prev_val = prev_val + [None] * (len(val)-len(prev_val) if val_is_list else 1)
         if isinstance(val, NestedArg) and subtypehints is not None:
             val = (prev_val[:-1] if isinstance(prev_val, list) else []) + [val]
+        elif isinstance(val, Iterable) and not isinstance(val, (list, str)) and type(val) not in mapping_origin_types:
+            val = list(val)
         elif not isinstance(val, list):
             raise_unexpected_value(f'Expected a {typehint_origin}', val)
         if subtypehints is not None:

--- a/jsonargparse/typing.py
+++ b/jsonargparse/typing.py
@@ -4,7 +4,6 @@ import operator
 import os
 import pathlib
 import re
-from contextlib import suppress
 from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple, Type, Union
 
 from .optionals import final
@@ -14,7 +13,6 @@ __all__ = [
     'final',
     'is_final_class',
     'register_type',
-    'registered_types',
     'restricted_number_type',
     'restricted_string_type',
     'path_type',
@@ -307,6 +305,7 @@ def register_type_on_first_use(import_path: str, *args, **kwargs):
 
 def get_registered_type(type_class) -> Optional[RegisteredType]:
     if type_class not in registered_type_handlers:
+        from contextlib import suppress
         with suppress(AttributeError, ValueError):
             import_path = get_import_path(type_class)
             if import_path in registration_pending:
@@ -360,8 +359,8 @@ register_type(os.PathLike, str, str)
 register_type(complex)
 register_type_on_first_use('uuid.UUID')
 
-for path in [pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath]:
-    register_type(path, str, path, type_check=isinstance)
+for _path in [pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath]:
+    register_type(_path, str, _path, type_check=isinstance)
 
 
 def timedelta_deserializer(value):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -304,6 +304,13 @@ class TypeHintsTests(unittest.TestCase):
         self.assertEqual(cfg.list, ['a', 'b'])
 
 
+    def test_sequence_tuple_default(self):
+        parser = ArgumentParser()
+        parser.add_argument('--seq', type=Sequence[str], default=('one', 'two'))
+        cfg = parser.parse_args([])
+        self.assertEqual(cfg, parser.get_defaults())
+
+
     def test_tuple_ellipsis(self):
         parser = ArgumentParser(error_handler=None)
         parser.add_argument('--tuple', type=Tuple[float, ...])

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,6 @@ doc =
     sphinx-autodoc-typehints>=1.19.5
 maintainer =
     bump2version>=0.5.11
-    twine>=4.0.0
 
 
 [options.package_data]
@@ -83,7 +82,7 @@ jsonargparse =
 [metadata]
 name = jsonargparse
 version = 4.18.0
-description = Parsing of command line options, yaml/jsonnet config files and/or environment variables based on argparse.
+description = Implement minimal boilerplate CLIs derived from type hints and parse from command line, config files and environment variables.
 long_description_content_type = text/x-rst
 author = Mauricio Villegas
 author_email = mauricio@omnius.com

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -69,7 +69,14 @@ class CustomOutputChecker(OutputChecker):
 doctest.OutputChecker = CustomOutputChecker
 
 doctest_global_setup = '''
+import os
+import shutil
 import sys
+import tempfile
+from calendar import Calendar
+from dataclasses import dataclass
+from typing import Callable, Iterable, List
+import jsonargparse_tests
 from jsonargparse import *
 from jsonargparse.typing import *
 from jsonargparse_tests.base import doctest_mock_class_in_main

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -22,6 +22,7 @@ jsonargparse
 jsonargparse.typing
 -------------------
 .. automodule:: jsonargparse.typing
+    :exclude-members: get_import_path, import_object, Path
 
 
 Index


### PR DESCRIPTION
## What does this PR do?

- Separate readme section for override order.
- Fixed failure when using a sequence type and the default is a tuple.
- Fixed incorrect error line breaks and indentation.
- Exclude non-public objects from jsonargparse.typing documentation.
- Enable python 3.11 testing on circleci.
- Only run tests for master branch and pull requests that merge to master.
- Several other minor fixes and improvements.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
