### PR TITLE
Support parser subclasses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ v4.19.0 (2022-12-??)
 
 Added
 ^^^^^
-- ``CLI`` now exposes the ``fail_untyped`` parameter.
+- ``CLI`` now supports the ``fail_untyped`` and ``parser_class`` parameters.
 - ``bytes`` and ``bytearray`` registered on first use and decodes from standard
   Base64.
 - Support getting the import path of variables in modules, e.g.
@@ -32,6 +32,8 @@ Added
 - Path types now implement the ``os.PathLike`` protocol.
 - New path mode ``cc`` to not require the parent directory to exists but that it
   can be created.
+- The parent parser class is now used to create internal parsers `#171
+  <https://github.com/omni-us/jsonargparse/issues/171>`__.
 
 Fixed
 ^^^^^
@@ -46,6 +48,7 @@ Fixed
 - Argument links with target a subclass mixed with other types not working `#208
   <https://github.com/omni-us/jsonargparse/issues/208>`__.
 - Failures when using a sequence type and the default is a tuple.
+- Parent parser logger not being forwarded to subcommand and internal parsers.
 
 Changed
 ^^^^^^^
@@ -55,6 +58,9 @@ Changed
 - The ``signatures`` extras now installs the ``typeshed-client`` package.
 - ``validators`` package is no longer a dependency.
 - Path types are no longer a subclass of ``str``.
+- Parsing steps logging now at debug level.
+- Discarding ``init_args`` warning changed to log at debug level.
+- Removed replacing list instead of append warning.
 
 
 v4.18.0 (2022-11-29)

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Optional, Union
+
+from .namespace import Namespace
+from .type_checking import ArgumentParser
+
+parent_parser: ContextVar['ArgumentParser'] = ContextVar('parent_parser')
+parser_capture: ContextVar[bool] = ContextVar('parser_capture', default=False)
+defaults_cache: ContextVar[Optional[Namespace]] = ContextVar('defaults_cache', default=None)
+lenient_check: ContextVar[Union[bool, str]] = ContextVar('lenient_check', default=False)
+load_value_mode: ContextVar[Optional[str]] = ContextVar('load_value_mode', default=None)
+
+
+parser_context_vars = dict(
+    parent_parser=parent_parser,
+    parser_capture=parser_capture,
+    defaults_cache=defaults_cache,
+    lenient_check=lenient_check,
+    load_value_mode=load_value_mode,
+)
+
+
+@contextmanager
+def parser_context(**kwargs):
+    context_var_tokens = []
+    for name, value in kwargs.items():
+        context_var = parser_context_vars[name]
+        token = context_var.set(value)
+        context_var_tokens.append((context_var, token))
+    try:
+        yield
+    finally:
+        for context_var, token in context_var_tokens:
+            context_var.reset(token)

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -21,7 +21,9 @@ from typing import (
     Union,
 )
 
+from ._common import lenient_check, parser_context
 from .actions import (
+    Action,
     ActionConfigFile,
     ActionParser,
     _ActionConfigLoad,
@@ -37,7 +39,7 @@ from .actions import (
     parent_parsers,
     previous_config,
 )
-from .formatters import DefaultHelpFormatter, empty_help, formatter_context, get_env_var
+from .formatters import DefaultHelpFormatter, empty_help, get_env_var
 from .jsonnet import ActionJsonnet, ActionJsonnetExtVars
 from .jsonschema import ActionJsonSchema
 from .link_arguments import ActionLink, ArgumentLinking
@@ -46,7 +48,6 @@ from .loaders_dumpers import (
     dump_using_format,
     get_loader_exceptions,
     load_value,
-    load_value_context,
     loaders,
     set_omegaconf_loader,
     yaml_load,
@@ -79,8 +80,6 @@ from .util import (
     get_private_kwargs,
     identity,
     is_subclass,
-    lenient_check,
-    lenient_check_context,
     return_parser_if_captured,
     usage_and_exit_error_handler,
 )
@@ -134,9 +133,10 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
                     kwargs=kwargs,
                     enable_path=enable_path,
                     container=super(),
-                    logger=self.logger,
+                    logger=self._logger,
                 )
         action = super().add_argument(*args, **kwargs)
+        action.logger = self._logger  # type: ignore
         if isinstance(action, ActionConfigFile) and getattr(self, '_print_config', None) is not None:
             self.add_argument(self._print_config, action=_ActionPrintConfig)  # type: ignore
         if is_meta_key(action.dest):
@@ -169,7 +169,7 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
         parser = self.parser if hasattr(self, 'parser') else self
         if name is not None and name in parser.groups:
             raise ValueError(f'Group with name {name} already exists.')
-        group = _ArgumentGroup(parser, *args, logger=parser.logger, **kwargs)
+        group = _ArgumentGroup(parser, *args, logger=parser._logger, **kwargs)
         group.parser = parser
         parser._action_groups.append(group)
         if name is not None:
@@ -214,7 +214,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         are supported. Additionally it accepts:
 
         Args:
-            env_prefix: Prefix for environment variables.
+            env_prefix: Prefix for environment variables. ``True`` to derive from ``prog``.
             error_handler: Handler for parsing errors, if None raises :class:`.ParserError` exception.
             formatter_class: Class for printing help messages.
             logger: Configures the logger, see :class:`.LoggerProperty`.
@@ -252,18 +252,10 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         if caller not in {'jsonargparse', 'argcomplete'}:
             raise NotImplementedError('parse_known_args not implemented to dissuade its use, since typos in configs would go unnoticed.')
 
-        if args is None:
-            args = sys.argv[1:]
-        else:
-            args = list(args)
-            if not all(isinstance(a, str) for a in args):
-                self.error(f'All arguments are expected to be strings: {args}')
-        self.args = args
-
         namespace = argcomplete_namespace(caller, self, namespace)
 
         try:
-            with patch_namespace(), lenient_check_context(caller), ActionTypeHint.subclass_arg_context(self), load_value_context(self.parser_mode):
+            with patch_namespace(), parser_context(parent_parser=self, lenient_check=True), ActionTypeHint.subclass_arg_context(self):
                 namespace, args = self._parse_known_args(args, namespace)
         except (argparse.ArgumentError, ParserError) as ex:
             self.error(str(ex), ex)
@@ -290,7 +282,6 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         skip_required: bool = False,
         skip_subcommands: bool = False,
         fail_no_subcommand: bool = True,
-        log_message: Optional[str] = None,
     ) -> Namespace:
         """Common parsing code used by other parse methods.
 
@@ -303,7 +294,6 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             skip_required: Whether to skip check of required arguments.
             skip_subcommands: Whether to skip subcommand processing.
             fail_no_subcommand: Whether to fail if no subcommand given.
-            log_message: Message to log at INFO level after parsing.
 
         Returns:
             A config object with all parsed values.
@@ -315,12 +305,12 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             _ActionSubCommands.handle_subcommands(self, cfg, env=env, defaults=defaults, fail_no_subcommand=fail_no_subcommand)
 
         if defaults:
-            with lenient_check_context():
+            with parser_context(lenient_check=True):
                 ActionTypeHint.add_sub_defaults(self, cfg)
 
         _ActionPrintConfig.print_config_if_requested(self, cfg)
 
-        with load_value_context(self.parser_mode):
+        with parser_context(parent_parser=self):
             ActionLink.apply_parsing_links(self, cfg)
 
             if not skip_check and not lenient_check.get():
@@ -328,9 +318,6 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
 
         if not (with_meta or (with_meta is None and self._default_meta)):
             cfg = strip_meta(cfg)
-
-        if log_message is not None:
-            self._logger.info(log_message)
 
         return cfg
 
@@ -348,7 +335,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         if env or (env is None and self._default_env):
             if environ is None:
                 environ = os.environ
-            with load_value_context(self.parser_mode):
+            with parser_context(load_value_mode=self.parser_mode):
                 cfg_env = self._load_env_vars(env=environ, defaults=defaults)
             cfg = self.merge_config(cfg_env, cfg)
 
@@ -386,6 +373,14 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         return_parser_if_captured(self)
         argcomplete_autocomplete(self)
 
+        if args is None:
+            args = sys.argv[1:]
+        else:
+            args = list(args)
+            if not all(isinstance(a, str) for a in args):
+                self.error(f'All arguments are expected to be strings: {args}')
+        self.args = args
+
         try:
             cfg = self._parse_defaults_and_environ(defaults, env)
             if namespace:
@@ -402,12 +397,12 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 defaults=defaults,
                 with_meta=with_meta,
                 skip_check=skip_check,
-                log_message='Parsed command line arguments.',
             )
 
         except (TypeError, KeyError) as ex:
             self.error(str(ex), ex)
 
+        self._logger.debug('Parsed command line arguments: %s', args)
         return parsed_cfg
 
 
@@ -441,8 +436,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             if cfg_base:
                 cfg = self.merge_config(cfg_base, cfg)
 
-            cfg_obj = self._apply_actions(cfg_obj, prev_cfg=cfg)
-            cfg = self.merge_config(cfg_obj, cfg)
+            cfg_apply = self._apply_actions(cfg_obj, prev_cfg=cfg)
+            cfg = self.merge_config(cfg_apply, cfg)
 
             parsed_cfg = self._parse_common(
                 cfg=cfg,
@@ -451,12 +446,12 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 with_meta=with_meta,
                 skip_check=skip_check,
                 skip_required=skip_required,
-                log_message='Parsed object.',
             )
 
         except (TypeError, KeyError) as ex:
             self.error(str(ex), ex)
 
+        self._logger.debug('Parsed object: %s', cfg_obj)
         return parsed_cfg
 
 
@@ -525,12 +520,12 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 with_meta=with_meta,
                 skip_check=skip_check,
                 skip_subcommands=skip_subcommands,
-                log_message='Parsed environment variables.',
             )
 
         except (TypeError, KeyError) as ex:
             self.error(str(ex), ex)
 
+        self._logger.debug('Parsed environment variables')
         return parsed_cfg
 
 
@@ -571,8 +566,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 **kwargs,
             )
 
-        self._logger.info(f'Parsed {self.parser_mode} from path: {cfg_path}')
-
+        self._logger.debug('Parsed configuration from path: %s', cfg_path)
         return parsed_cfg
 
 
@@ -605,7 +599,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         skip_check, fail_no_subcommand = get_private_kwargs(kwargs, _skip_check=False, _fail_no_subcommand=True)
 
         try:
-            with load_value_context(self.parser_mode):
+            with parser_context(load_value_mode=self.parser_mode):
                 cfg = self._load_config_parser_mode(cfg_str, cfg_path, ext_vars, previous_config.get())
 
             if defaults or env:
@@ -619,12 +613,12 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 with_meta=with_meta,
                 skip_check=skip_check,
                 fail_no_subcommand=fail_no_subcommand,
-                log_message=f'Parsed {self.parser_mode} string.',
             )
 
         except (TypeError, KeyError) as ex:
             self.error(str(ex), ex)
 
+        self._logger.debug('Parsed %s string: %s', self.parser_mode, cfg_str)
         return parsed_cfg
 
 
@@ -677,14 +671,14 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         """
         if 'description' not in kwargs:
             kwargs['description'] = 'For more details of each subcommand, add it as an argument followed by --help.'
-        with formatter_context(self):
+        with parser_context(parent_parser=self):
             subcommands: _ActionSubCommands = super().add_subparsers(dest=dest, **kwargs)  # type: ignore
         if required:
             self.required_args.add(dest)
         subcommands._required = required  # type: ignore
         subcommands.required = False
-        subcommands.parent_parser = self  # type: ignore
-        subcommands._env_prefix = self.env_prefix
+        subcommands.parent_parser = self
+        subcommands.env_prefix = get_env_var(self)
         self._subcommands_action = subcommands
         return subcommands
 
@@ -721,7 +715,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         cfg = strip_meta(cfg)
         ActionLink.strip_link_target_keys(self, cfg)
 
-        with load_value_context(self.parser_mode):
+        with parser_context(load_value_mode=self.parser_mode):
             if not skip_check:
                 self.check_config(cfg)
 
@@ -736,7 +730,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 self._dump_cleanup_actions(defaults, self._actions, {'skip_check': True, 'skip_none': skip_none})
                 self._dump_delete_default_entries(cfg_dict, defaults.as_dict())
 
-        with formatter_context(self):
+        with parser_context(parent_parser=self):
             return dump_using_format(self, cfg_dict, 'yaml_comments' if yaml_comments else format)
 
 
@@ -755,7 +749,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             elif isinstance(action, ActionTypeHint):
                 value = cfg.get(action_dest)
                 if value is not None:
-                    value = action.serialize(value, dump_kwargs=dump_kwargs)
+                    with parser_context(parent_parser=self):
+                        value = action.serialize(value, dump_kwargs=dump_kwargs)
                     cfg.update(value, action_dest)
 
 
@@ -767,7 +762,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 class_object_val = None
                 if is_subclass_spec(val):
                     if val['class_path'] != default.get('class_path'):
-                        parser = ActionTypeHint.get_class_parser(val['class_path'])
+                        with parser_context(parent_parser=self):
+                            parser = ActionTypeHint.get_class_parser(val['class_path'])
                         default = {'init_args': parser.get_defaults().as_dict()}
                     class_object_val = val
                     val = val.get('init_args')
@@ -839,7 +835,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             ActionLink.strip_link_target_keys(self, cfg)
 
             if not skip_check:
-                with load_value_context(self.parser_mode):
+                with parser_context(load_value_mode=self.parser_mode):
                     self.check_config(strip_meta(cfg), branch=branch)
 
             def save_paths(cfg):
@@ -868,7 +864,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                             f.write(val.get_content())
                         cfg[key] = type(val)(str(val_path))
 
-            with change_to_path_dir(path_fc), formatter_context(self):
+            with change_to_path_dir(path_fc), parser_context(parent_parser=self):
                 save_paths(cfg)
             dump_kwargs['skip_check'] = True
             with open(path_fc(), 'w') as f:
@@ -968,11 +964,11 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             ):
                 cfg[action.dest] = recreate_branches(action.default)
 
-        self._logger.info('Loaded default values from parser.')
+        self._logger.debug('Loaded default values from parser')
 
         default_config_files = self._get_default_config_files()
         for key, default_config_file in default_config_files:
-            with change_to_path_dir(default_config_file), load_value_context(self.parser_mode):
+            with change_to_path_dir(default_config_file), parser_context(parent_parser=self):
                 cfg_file = self._load_config_parser_mode(default_config_file.get_content())
                 if key is not None:
                     cfg_file = cfg_file.get(key)
@@ -996,7 +992,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 cfg['__default_config__'] = [meta, default_config_file]
             else:
                 cfg['__default_config__'] = default_config_file
-            self._logger.info(f'Parsed configuration from default path: {default_config_file}')
+            self._logger.debug('Parsed default configuration from path: %s', default_config_file)
 
         ActionTypeHint.add_sub_defaults(self, cfg)
 
@@ -1084,7 +1080,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         try:
             if not skip_required and not lenient_check.get():
                 check_required(cfg, self)
-            with load_value_context(self.parser_mode):
+            with parser_context(load_value_mode=self.parser_mode):
                 check_values(cfg)
         except (TypeError, KeyError) as ex:
             prefix = 'Configuration check failed :: '
@@ -1133,10 +1129,10 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                     pass
                 else:
                     if value is not None:
-                        with load_value_context(self.parser_mode):
+                        with parser_context(parent_parser=self):
                             parent[key] = component.instantiate_classes(value)
             else:
-                with load_value_context(self.parser_mode):
+                with parser_context(load_value_mode=self.parser_mode):
                     component.instantiate_class(component, cfg)
 
         ActionLink.apply_instantiation_links(self, cfg, order=order)
@@ -1203,13 +1199,13 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
                 note = f'tried getting defaults considering default_config_files but failed due to: {ex}'
             group = self._default_config_files_group
             group.description = f'{self._default_config_files}, Note: {note}'
-        with formatter_context(self, defaults):
+        with parser_context(parent_parser=self, defaults_cache=defaults):
             help_str = super().format_help()
         return help_str
 
 
     def print_usage(self, file=None):
-        with formatter_context(self):
+        with parser_context(parent_parser=self):
             return super().print_usage(file)
 
 
@@ -1265,7 +1261,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             value = cfg[action_dest]
             if skip_fn and skip_fn(value):
                 continue
-            with lenient_check_context(), load_value_context(self.parser_mode):
+            with parser_context(parent_parser=self, lenient_check=True):
                 value = self._check_value_key(action, value, action_dest, prev_cfg)
             if isinstance(action, _ActionConfigLoad):
                 config_keys.add(action_dest)
@@ -1287,7 +1283,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             A new object with the merged configuration.
         """
         cfg = cfg_to.clone()
-        ActionTypeHint.discard_init_args_on_class_path_change(self, cfg, cfg_from)
+        with parser_context(parent_parser=self):
+            ActionTypeHint.discard_init_args_on_class_path_change(self, cfg, cfg_from)
         cfg.update(cfg_from)
         ActionTypeHint.apply_appends(self, cfg)
         return cfg
@@ -1316,7 +1313,8 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
             if isinstance(value, str):
                 value = action.check_type(value, self)
         elif hasattr(action, '_check_type'):
-            value = action._check_type(value, cfg=cfg)
+            with parser_context(parent_parser=self):
+                value = action._check_type(value, cfg=cfg)
         elif action.type is not None:
             try:
                 if action.nargs in {None, '?'} or action.nargs == 0:
@@ -1428,7 +1426,7 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
 
 
     @default_meta.setter
-    def default_meta(self, default_meta:bool):
+    def default_meta(self, default_meta: bool):
         if isinstance(default_meta, bool):
             self._default_meta = default_meta
         else:
@@ -1445,25 +1443,23 @@ class ArgumentParser(ActionsContainer, ArgumentLinking, argparse.ArgumentParser)
         Raises:
             ValueError: If an invalid value is given.
         """
-        return self._env_prefix  # type: ignore
+        return self._env_prefix
 
 
     @env_prefix.setter
     def env_prefix(self, env_prefix: Union[bool, str]):
-        if env_prefix is False:
-            self._env_prefix = None
-        elif env_prefix in {True, None}:
-            if env_prefix is None:
-                from .deprecated import (
-                    deprecation_warning,
-                    env_prefix_property_none_message,
-                )
-                deprecation_warning(ArgumentParser, env_prefix_property_none_message)
-            self._env_prefix = os.path.splitext(self.prog)[0]
-        elif isinstance(env_prefix, str):
-            self._env_prefix = env_prefix
-        else:
-            raise ValueError('env_prefix has to be a string or None.')
+        if env_prefix is None:
+            from .deprecated import (
+                deprecation_warning,
+                env_prefix_property_none_message,
+            )
+            deprecation_warning(ArgumentParser, env_prefix_property_none_message)
+            env_prefix = False
+        elif env_prefix is True:
+            env_prefix = os.path.splitext(self.prog)[0]
+        elif not isinstance(env_prefix, (bool, str)):
+            raise ValueError('env_prefix must be a string or a boolean.')
+        self._env_prefix = env_prefix
 
 
     @property

--- a/jsonargparse/jsonnet.py
+++ b/jsonargparse/jsonnet.py
@@ -1,11 +1,11 @@
 """Actions to support jsonnet."""
 
-from argparse import Action
 from typing import Any, Dict, Optional, Tuple, Union
 
-from .actions import _is_action_value_list
+from ._common import parser_context
+from .actions import Action, _is_action_value_list
 from .jsonschema import ActionJsonSchema
-from .loaders_dumpers import get_loader_exceptions, load_value, load_value_context
+from .loaders_dumpers import get_loader_exceptions, load_value
 from .optionals import (
     get_config_read_mode,
     get_jsonschema_exceptions,
@@ -64,7 +64,7 @@ class ActionJsonnet(Action):
             if schema is not None:
                 jsonvalidator = import_jsonschema('ActionJsonnet')[1]
                 if isinstance(schema, str):
-                    with load_value_context('yaml'):
+                    with parser_context(load_value_mode='yaml'):
                         try:
                             schema = load_value(schema)
                         except get_loader_exceptions() as ex:
@@ -163,7 +163,7 @@ class ActionJsonnet(Action):
             fname = jsonnet(absolute=False) if isinstance(jsonnet, Path) else jsonnet
             snippet = fpath.get_content()
         try:
-            with load_value_context('yaml'):
+            with parser_context(load_value_mode='yaml'):
                 values = load_value(_jsonnet.evaluate_snippet(fname, snippet, ext_vars=ext_vars, ext_codes=ext_codes))
         except RuntimeError as ex:
             raise ParserError(f'Problems evaluating jsonnet "{fname}" :: {ex}') from ex

--- a/jsonargparse/jsonschema.py
+++ b/jsonargparse/jsonschema.py
@@ -1,11 +1,11 @@
 """Action to support jsonschemas."""
 
 import os
-from argparse import Action
 from typing import Dict, Optional, Union
 
-from .actions import _is_action_value_list
-from .loaders_dumpers import get_loader_exceptions, load_value, load_value_context
+from ._common import parser_context
+from .actions import Action, _is_action_value_list
+from .loaders_dumpers import get_loader_exceptions, load_value
 from .namespace import strip_meta
 from .optionals import (
     argcomplete_warn_redraw_prompt,
@@ -40,7 +40,7 @@ class ActionJsonSchema(Action):
         """
         if schema is not None:
             if isinstance(schema, str):
-                with load_value_context('yaml'):
+                with parser_context(load_value_mode='yaml'):
                     try:
                         schema = load_value(schema)
                     except get_loader_exceptions() as ex:

--- a/jsonargparse/link_arguments.py
+++ b/jsonargparse/link_arguments.py
@@ -2,13 +2,15 @@
 
 import inspect
 import re
-from argparse import SUPPRESS, Action
+from argparse import SUPPRESS
+from argparse import Action as ArgparseAction
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 from .actions import (
+    Action,
     ActionConfigFile,
     _ActionConfigLoad,
     _ActionSubCommands,
@@ -24,9 +26,9 @@ __all__ = ['ArgumentLinking']
 def find_parent_or_child_actions(
     parser: 'ArgumentParser',
     key: str,
-    exclude: Optional[Union[Type[Action], Tuple[Type[Action], ...]]] = None,
-) -> Optional[List[Action]]:
-    found: List[Action] = []
+    exclude: Optional[Union[Type[ArgparseAction], Tuple[Type[ArgparseAction], ...]]] = None,
+) -> Optional[List[ArgparseAction]]:
+    found: List[ArgparseAction] = []
     action = _find_parent_action(parser, key, exclude=exclude)
     if action is not None:
         found = [action]
@@ -42,8 +44,8 @@ def find_parent_or_child_actions(
 def find_subclass_action_or_class_group(
     parser: 'ArgumentParser',
     key: str,
-    exclude: Optional[Union[Type[Action], Tuple[Type[Action], ...]]] = None,
-) -> Optional[Union[Action, '_ArgumentGroup']]:
+    exclude: Optional[Union[Type[ArgparseAction], Tuple[Type[ArgparseAction], ...]]] = None,
+) -> Optional[Union[ArgparseAction, '_ArgumentGroup']]:
     from .typehints import ActionTypeHint
     action = _find_parent_action(parser, key, exclude=exclude)
     if ActionTypeHint.is_subclass_typehint(action):

--- a/jsonargparse/optionals.py
+++ b/jsonargparse/optionals.py
@@ -248,9 +248,9 @@ class FilesCompleterMethod:
 
 def argcomplete_autocomplete(parser):
     if argcomplete_support:
-        argcomplete = import_argcomplete('parse_args')
-        from .loaders_dumpers import load_value_context
-        with load_value_context(parser.parser_mode):
+        argcomplete = import_argcomplete('argcomplete_autocomplete')
+        from ._common import parser_context
+        with parser_context(load_value_mode=parser.parser_mode):
             argcomplete.autocomplete(parser)
 
 

--- a/jsonargparse_tests/test_argcomplete.py
+++ b/jsonargparse_tests/test_argcomplete.py
@@ -10,7 +10,7 @@ from io import StringIO
 from typing import List, Optional
 
 from jsonargparse import ActionConfigFile, ActionJsonSchema, ActionYesNo, ArgumentParser
-from jsonargparse.loaders_dumpers import load_value_context
+from jsonargparse._common import parser_context
 from jsonargparse.optionals import (
     argcomplete_support,
     import_argcomplete,
@@ -44,7 +44,7 @@ class ArgcompleteTests(TempDirTestCase):
         os.environ['COMP_TYPE'] = str(ord('?'))   # ='63'  str(ord('\t'))='9'
         self.parser = ArgumentParser(error_handler=lambda x: x.exit(2))
         stack = ExitStack()
-        stack.enter_context(load_value_context('yaml'))
+        stack.enter_context(parser_context(load_value_mode='yaml'))
         self.addCleanup(stack.close)
 
 

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -9,12 +9,8 @@ from typing import List
 import yaml
 
 from jsonargparse import ActionConfigFile, ArgumentParser, set_dumper, set_loader
-from jsonargparse.loaders_dumpers import (
-    load_value,
-    load_value_context,
-    loaders,
-    yaml_dump,
-)
+from jsonargparse._common import parser_context
+from jsonargparse.loaders_dumpers import load_value, loaders, yaml_dump
 
 
 class LoadersTests(unittest.TestCase):
@@ -118,7 +114,7 @@ class LoadersTests(unittest.TestCase):
 
 
     def test_load_value_dash(self):
-        with load_value_context('yaml'):
+        with parser_context(load_value_mode='yaml'):
             self.assertEqual('-', load_value('-'))
             self.assertEqual(' -  ', load_value(' -  '))
 


### PR DESCRIPTION
## What does this PR do?

As the title says plus fixes and improvements identified while implementing this:
- Fixed parent parser logger not being forwarded to subcommand and internal parsers.
- CLI now supports the parser_class parameter.
- Parsing steps logging now at debug level.
- Discarding init_args warning changed to log at debug level.
- Removed replacing list instead of append warning.
- Refactored some of the context managers and context variables.

Fixes #171

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
