### PR TITLE
Deprecate ArgumentParser.error_handler in favour of exit_on_error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ paths are considered internals and can change in minor and patch releases.
 v4.20.0 (2023-01-??)
 --------------------
 
+Changed
+^^^^^^^
+- When parsing fails now ``argparse.ArgumentError`` is raised instead of
+  ``ParserError``.
+
 Deprecated
 ^^^^^^^^^^
 - Path ``skip_check`` parameter is deprecated and will be removed in v5.0.0.
@@ -24,6 +29,8 @@ Deprecated
   absolute``.
 - ``ActionPathList`` is deprecated and will be removed in v5.0.0. Instead use as
   type ``List[<path_type>]`` with ``enable_path=True``.
+- ``ArgumentParser.error_handler`` is deprecated and will be removed in v5.0.0.
+  Instead use the new exit_on_error parameter from argparse.
 
 
 v4.19.0 (2022-12-27)

--- a/README.rst
+++ b/README.rst
@@ -318,7 +318,7 @@ shown above you would observe:
 
 If the parsing fails the standard behavior is that the usage is printed and the
 program is terminated. Alternatively you can initialize the parser with
-``error_handler=None`` in which case a :class:`.ParserError` is raised.
+``exit_on_error=False`` in which case an :class:`.ArgumentError` is raised.
 
 
 Override order

--- a/jsonargparse/__init__.py
+++ b/jsonargparse/__init__.py
@@ -1,4 +1,12 @@
-from argparse import ONE_OR_MORE, OPTIONAL, PARSER, REMAINDER, SUPPRESS, ZERO_OR_MORE
+from argparse import (
+    ONE_OR_MORE,
+    OPTIONAL,
+    PARSER,
+    REMAINDER,
+    SUPPRESS,
+    ZERO_OR_MORE,
+    ArgumentError,
+)
 
 from .actions import *
 from .cli import *
@@ -16,6 +24,7 @@ from .typehints import *
 from .util import *
 
 __all__ = [
+    'ArgumentError',
     'OPTIONAL',
     'REMAINDER',
     'SUPPRESS',

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -18,8 +18,8 @@ from .type_checking import ArgumentParser
 from .util import (
     LoggerProperty,
     NoneType,
-    ParserError,
     Path,
+    argument_error,
     change_to_path_dir,
     default_config_option_help,
     get_typehint_origin,
@@ -246,7 +246,7 @@ class _ActionPrintConfig(Action):
             flags = value[0].split(',')
             invalid_flags = [f for f in flags if f not in valid_flags]
             if len(invalid_flags) > 0:
-                raise ParserError(f'Invalid option "{invalid_flags[0]}" for {option_string}')
+                raise argument_error(f'Invalid option "{invalid_flags[0]}" for {option_string}')
             for flag in [f for f in flags if f != '']:
                 kwargs[valid_flags[flag]] = True
         while hasattr(parser, 'parent_parser'):
@@ -383,7 +383,7 @@ class _ActionHelpClassPath(Action):
         args = self.get_args_after_opt(parser.args)
         if args:
             subparser.parse_args(args)
-            raise ParserError(f'Expected a nested --*.help option, got: {args}.')
+            raise argument_error(f'Expected a nested --*.help option, got: {args}.')
         else:
             subparser.print_help()
             parser.exit()
@@ -598,7 +598,8 @@ class _ActionSubCommands(_SubParsersAction):
         parser.default_env = self.parent_parser.default_env
         parser.parent_parser = self.parent_parser
         parser.parser_mode = self.parent_parser.parser_mode
-        parser.error_handler = self.parent_parser.error_handler
+        parser._error_handler = self.parent_parser._error_handler
+        parser.exit_on_error = self.parent_parser.exit_on_error
         parser.logger = self.parent_parser.logger
         parser.subcommand = name
 

--- a/jsonargparse/jsonnet.py
+++ b/jsonargparse/jsonnet.py
@@ -12,7 +12,7 @@ from .optionals import (
     import_jsonnet,
     import_jsonschema,
 )
-from .util import ParserError, Path
+from .util import Path, argument_error
 
 __all__ = [
     'ActionJsonnetExtVars',
@@ -166,7 +166,7 @@ class ActionJsonnet(Action):
             with parser_context(load_value_mode='yaml'):
                 values = load_value(_jsonnet.evaluate_snippet(fname, snippet, ext_vars=ext_vars, ext_codes=ext_codes))
         except RuntimeError as ex:
-            raise ParserError(f'Problems evaluating jsonnet "{fname}" :: {ex}') from ex
+            raise argument_error(f'Problems evaluating jsonnet "{fname}": {ex}') from ex
         if self._validator is not None:
             self._validator.validate(values)
         if with_meta:

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -8,6 +8,7 @@ import stat
 import sys
 import textwrap
 import warnings
+from argparse import ArgumentError
 from collections import Counter, namedtuple
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -48,10 +49,8 @@ __all__ = [
     'class_from_function',
     'LoggerProperty',
     'null_logger',
-    'ParserError',
     'Path',
     'register_unresolvable_import_paths',
-    'usage_and_exit_error_handler',
 ]
 
 
@@ -73,12 +72,8 @@ class UrlData:
     url_path: str
 
 
-class ParserError(Exception):
-    """Error raised when parsing a value fails."""
-
-
-class DebugException(Exception):
-    pass
+def argument_error(message: str) -> ArgumentError:
+    return ArgumentError(None, message)
 
 
 class JsonargparseWarning(UserWarning):
@@ -157,25 +152,6 @@ def parse_value_or_config(value: Any, enable_path: bool = True, simple_types: bo
     if nested_arg:
         value = NestedArg(key=nested_arg.key, val=value)  # type: ignore
     return value, cfg_path
-
-
-def usage_and_exit_error_handler(parser: 'ArgumentParser', message: str) -> None:
-    """Error handler that prints the usage and exits with error code 2 (same behavior as argparse).
-
-    If the JSONARGPARSE_DEBUG environment variable is set, instead of exit, a
-    DebugException is raised.
-
-    Args:
-        parser: The parser object.
-        message: The message describing the error being handled.
-    """
-    parser.print_usage(sys.stderr)
-    args = {'prog': parser.prog, 'message': message}
-    sys.stderr.write('%(prog)s: error: %(message)s\n' % args)
-    if 'JSONARGPARSE_DEBUG' in os.environ:
-        raise DebugException('jsonargparse debug enabled, thus raising exception instead of exit.')
-    else:
-        parser.exit(2)
 
 
 class CachedStdin(StringIO):

--- a/jsonargparse_tests/test_argcomplete.py
+++ b/jsonargparse_tests/test_argcomplete.py
@@ -42,7 +42,7 @@ class ArgcompleteTests(TempDirTestCase):
         os.environ['_ARGCOMPLETE_SUPPRESS_SPACE'] = '1'
         os.environ['_ARGCOMPLETE_COMP_WORDBREAKS'] = " \t\n\"'><=;|&(:"
         os.environ['COMP_TYPE'] = str(ord('?'))   # ='63'  str(ord('\t'))='9'
-        self.parser = ArgumentParser(error_handler=lambda x: x.exit(2))
+        self.parser = ArgumentParser()
         stack = ExitStack()
         stack.enter_context(parser_context(load_value_mode='yaml'))
         self.addCleanup(stack.close)

--- a/jsonargparse_tests/test_jsonnet.py
+++ b/jsonargparse_tests/test_jsonnet.py
@@ -14,8 +14,8 @@ from jsonargparse import (
     ActionJsonnet,
     ActionJsonnetExtVars,
     ActionJsonSchema,
+    ArgumentError,
     ArgumentParser,
-    ParserError,
     strip_meta,
 )
 from jsonargparse.optionals import jsonnet_support
@@ -71,7 +71,7 @@ example_schema = {
 class JsonnetTests(TempDirTestCase):
 
     def test_parser_mode_jsonnet(self):
-        parser = ArgumentParser(parser_mode='jsonnet', error_handler=None)
+        parser = ArgumentParser(parser_mode='jsonnet', exit_on_error=False)
         parser.add_argument('--cfg',
             action=ActionConfigFile)
         parser.add_argument('--param',
@@ -89,7 +89,7 @@ class JsonnetTests(TempDirTestCase):
         self.assertEqual('#8', cfg.records[-2]['ref'])
         self.assertEqual(15.5, cfg.records[-2]['val'])
 
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--cfg', '{}}']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--cfg', '{}}']))
 
 
     def test_parser_mode_jsonnet_import_issue_122(self):
@@ -123,7 +123,7 @@ class JsonnetTests(TempDirTestCase):
             def __init__(self, name: str = 'Lucky', prize: int = 100):
                 pass
 
-        parser = ArgumentParser(parser_mode='jsonnet', error_handler=None)
+        parser = ArgumentParser(parser_mode='jsonnet', exit_on_error=False)
         parser.add_class_arguments(Class, 'group', sub_configs=True)
 
         cfg = parser.parse_args([f'--group={config_path}'])
@@ -132,7 +132,7 @@ class JsonnetTests(TempDirTestCase):
 
 
     def test_ActionJsonnet(self):
-        parser = ArgumentParser(default_meta=False, error_handler=None)
+        parser = ArgumentParser(default_meta=False, exit_on_error=False)
         parser.add_argument('--input.ext_vars',
             action=ActionJsonnetExtVars())
         parser.add_argument('--input.jsonnet',
@@ -147,15 +147,15 @@ class JsonnetTests(TempDirTestCase):
         cfg1 = parser.parse_args(['--input.jsonnet', example_1_jsonnet])
         self.assertEqual(cfg1.input.jsonnet['records'], cfg2.input.jsonnet['records'])
 
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--input.ext_vars', '{"param": "a"}', '--input.jsonnet', example_2_jsonnet]))
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--input.jsonnet', example_2_jsonnet]))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--input.ext_vars', '{"param": "a"}', '--input.jsonnet', example_2_jsonnet]))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--input.jsonnet', example_2_jsonnet]))
 
         self.assertRaises(ValueError, lambda: ActionJsonnet(ext_vars=2))
         self.assertRaises(ValueError, lambda: ActionJsonnet(schema='.'+json.dumps(example_schema)))
 
 
     def test_ActionJsonnet_save(self):
-        parser = ArgumentParser(error_handler=None)
+        parser = ArgumentParser(exit_on_error=False)
         parser.add_argument('--ext_vars',
             action=ActionJsonnetExtVars())
         parser.add_argument('--jsonnet',
@@ -210,7 +210,7 @@ class JsonnetTests(TempDirTestCase):
 
 
     def test_ActionJsonnet_parse(self):
-        parser = ArgumentParser(error_handler=None)
+        parser = ArgumentParser(exit_on_error=False)
         parser.add_argument('--ext_vars',
             action=ActionJsonnetExtVars())
 

--- a/jsonargparse_tests/test_jsonschema.py
+++ b/jsonargparse_tests/test_jsonschema.py
@@ -6,7 +6,12 @@ import re
 import unittest
 from io import StringIO
 
-from jsonargparse import ActionConfigFile, ActionJsonSchema, ArgumentParser, ParserError
+from jsonargparse import (
+    ActionConfigFile,
+    ActionJsonSchema,
+    ArgumentError,
+    ArgumentParser,
+)
 from jsonargparse.optionals import jsonschema_support
 from jsonargparse_tests.base import TempDirTestCase, is_posix
 
@@ -50,7 +55,7 @@ schema3 = {
 class JsonSchemaTests(TempDirTestCase):
 
     def test_ActionJsonSchema(self):
-        parser = ArgumentParser(prog='app', default_meta=False, error_handler=None)
+        parser = ArgumentParser(prog='app', default_meta=False, exit_on_error=False)
         parser.add_argument('--op1',
             action=ActionJsonSchema(schema=schema1))
         parser.add_argument('--op2',
@@ -64,14 +69,14 @@ class JsonSchemaTests(TempDirTestCase):
         op2_val = {'k1': 'one', 'k2': 2, 'k3': 3.3}
 
         self.assertEqual(op1_val, parser.parse_args(['--op1', str(op1_val)]).op1)
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--op1', '[1, "two"]']))
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--op1', '[1.5, 2]']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--op1', '[1, "two"]']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--op1', '[1.5, 2]']))
 
         self.assertEqual(op2_val, parser.parse_args(['--op2', str(op2_val)]).op2)
         self.assertEqual(17, parser.parse_args(['--op2', '{"k2": 2}']).op2['k3'])
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--op2', '{"k1": 1}']))
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--op2', '{"k2": "2"}']))
-        self.assertRaises(ParserError, lambda: parser.parse_args(['--op2', '{"k4": 4}']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--op2', '{"k1": 1}']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--op2', '{"k2": "2"}']))
+        self.assertRaises(ArgumentError, lambda: parser.parse_args(['--op2', '{"k4": 4}']))
 
         op1_file = os.path.join(self.tmpdir, 'op1.json')
         op2_file = os.path.join(self.tmpdir, 'op2.json')
@@ -101,7 +106,7 @@ class JsonSchemaTests(TempDirTestCase):
 
         if is_posix:
             os.chmod(op1_file, 0)
-            self.assertRaises(ParserError, lambda: parser.parse_path(cfg1_file))
+            self.assertRaises(ArgumentError, lambda: parser.parse_path(cfg1_file))
 
 
     def test_ActionJsonSchema_failures(self):

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -16,7 +16,7 @@ from jsonargparse.loaders_dumpers import load_value, loaders, yaml_dump
 class LoadersTests(unittest.TestCase):
 
     def test_set_dumper_custom_yaml(self):
-        parser = ArgumentParser(error_handler=None)
+        parser = ArgumentParser(exit_on_error=False)
         parser.add_argument('--list', type=List[int])
 
         def custom_yaml_dump(data) -> str:
@@ -30,7 +30,7 @@ class LoadersTests(unittest.TestCase):
 
 
     def test_disable_implicit_mapping_values(self):
-        parser = ArgumentParser(error_handler=None)
+        parser = ArgumentParser(exit_on_error=False)
         parser.add_argument('--val', type=str)
         self.assertEqual('{one}', parser.parse_args(['--val={one}']).val)
         self.assertEqual('{one,two,three}', parser.parse_args(['--val={one,two,three}']).val)
@@ -38,7 +38,7 @@ class LoadersTests(unittest.TestCase):
 
     @unittest.skipIf(not find_spec('omegaconf'), 'omegaconf package is required')
     def test_parser_mode_omegaconf(self):
-        parser = ArgumentParser(error_handler=None, parser_mode='omegaconf')
+        parser = ArgumentParser(exit_on_error=False, parser_mode='omegaconf')
         parser.add_argument('--server.host', type=str)
         parser.add_argument('--server.port', type=int)
         parser.add_argument('--client.url', type=str)
@@ -66,7 +66,7 @@ class LoadersTests(unittest.TestCase):
         subparser.add_argument('--source', type=str)
         subparser.add_argument('--target', type=str)
 
-        parser = ArgumentParser(error_handler=None, parser_mode='omegaconf')
+        parser = ArgumentParser(exit_on_error=False, parser_mode='omegaconf')
         subcommands = parser.add_subcommands()
         subcommands.add_subcommand('sub', subparser)
 

--- a/jsonargparse_tests/test_stubs_resolver.py
+++ b/jsonargparse_tests/test_stubs_resolver.py
@@ -179,7 +179,7 @@ class StubsResolverTests(unittest.TestCase):
         if sys.version_info >= (3, 10):
             self.assertTrue(all(p.annotation != inspect._empty for p in params))
 
-        parser = ArgumentParser(error_handler=None)
+        parser = ArgumentParser(exit_on_error=False)
         parser.add_function_arguments(get, fail_untyped=False)
         self.assertEqual(['url', 'params'], list(parser.get_defaults().keys()))
         help_str = StringIO()


### PR DESCRIPTION
## What does this PR do?

- ArgumentParser.error_handler is now deprecated and will be removed in v5.0.0.
- When parsing fails now argparse.ArgumentError is raised instead of ParserError.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
