### PR TITLE
Fix subcommand failure for required arg given in default config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ paths are considered internals and can change in minor and patch releases.
 v4.20.0 (2023-01-??)
 --------------------
 
+Fixed
+^^^^^
+- ``add_subcommands`` fails when parser has required argument and default config
+  available `#232 <https://github.com/omni-us/jsonargparse/issues/232>`__.
+
 Changed
 ^^^^^^^
 - When parsing fails now ``argparse.ArgumentError`` is raised instead of

--- a/jsonargparse/core.py
+++ b/jsonargparse/core.py
@@ -670,7 +670,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         """
         if 'description' not in kwargs:
             kwargs['description'] = 'For more details of each subcommand, add it as an argument followed by --help.'
-        with parser_context(parent_parser=self):
+        with parser_context(parent_parser=self, lenient_check=True):
             subcommands: _ActionSubCommands = super().add_subparsers(dest=dest, **kwargs)  # type: ignore
         if required:
             self.required_args.add(dest)

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import pathlib
 import pickle
 import sys
 import unittest
@@ -1010,6 +1011,19 @@ class ConfigFilesTests(TempDirTestCase):
         self.assertIn('defaults_0.yaml', out.getvalue())
         self.assertIn('defaults_1.yaml', out.getvalue())
         self.assertIn('defaults_2.yaml', out.getvalue())
+
+
+    def test_required_arg_in_default_config_and_add_subcommands(self):
+        pathlib.Path('config.yaml').write_text('output: test\nprepare:\n  media: test\n')
+        parser = ArgumentParser(default_config_files=['config.yaml'])
+        parser.add_argument('--output', required=True)
+        subcommands = parser.add_subcommands()
+        prepare = ArgumentParser()
+        prepare.add_argument('--media', required=True)
+        subcommands.add_subcommand('prepare', prepare)
+        cfg = parser.parse_args([])
+        self.assertEqual(str(cfg.__default_config__), 'config.yaml')
+        self.assertEqual(strip_meta(cfg), Namespace(output='test', prepare=Namespace(media='test'), subcommand='prepare'))
 
 
     def test_ActionConfigFile(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #232.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
