### PR TITLE
Allow `discard_init_args_on_class_path_change` to handle more nested contexts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.20.1 (2023-02-??)
+v4.20.1 (2023-03-??)
 --------------------
 
 Fixed
 ^^^^^
+- Allow ``discard_init_args_on_class_path_change`` to handle more nested contexts `#247
+  <https://github.com/omni-us/jsonargparse/issues/247>`__.
+
 - Dump not working for partial callable with return instance
   `pytorch-lightning#15340 (comment)
   <https://github.com/Lightning-AI/lightning/issues/15340#issuecomment-1439203008>`__.

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -939,8 +939,7 @@ def discard_init_args_on_class_path_change(parser_or_action, prev_val, value):
             sub_add_kwargs = getattr(parser_or_action, 'sub_add_kwargs', {})
             parser = ActionTypeHint.get_class_parser(value['class_path'], sub_add_kwargs)
         del_args = {}
-        if isinstance(prev_val, dict):
-            prev_val = subclass_spec_as_namespace(prev_val)
+        prev_val = subclass_spec_as_namespace(prev_val)
         for key, val in list(prev_val.init_args.__dict__.items()):
             action = _find_action(parser, key)
             if action:

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -939,6 +939,8 @@ def discard_init_args_on_class_path_change(parser_or_action, prev_val, value):
             sub_add_kwargs = getattr(parser_or_action, 'sub_add_kwargs', {})
             parser = ActionTypeHint.get_class_parser(value['class_path'], sub_add_kwargs)
         del_args = {}
+        if isinstance(prev_val, dict):
+            prev_val = subclass_spec_as_namespace(prev_val)
         for key, val in list(prev_val.init_args.__dict__.items()):
             action = _find_action(parser, key)
             if action:

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -1427,6 +1427,46 @@ class SignaturesConfigTests(TempDirTestCase):
                     self.assertIsInstance(init.main.sub, Sub2)
                     self.assertTrue(any("discarding init_args: {'s1': 'x'}" in o for o in log.output))
 
+    def test_config_nested_dict_discard_init_args(self):
+        class Base:
+            def __init__(self, b: float = 0.5):
+                pass
+
+        class Sub1(Base):
+            def __init__(self, s1: int = 3, **kwargs):
+                super().__init__(**kwargs)
+
+        class Sub2(Base):
+            def __init__(self, s2: int = 4, **kwargs):
+                super().__init__(**kwargs)
+
+        class Main:
+            def __init__(self, sub: Optional[Dict] = None) -> None:
+                self.sub = sub
+
+        configs, subconfigs, config_paths = {}, {}, {}
+        with mock_module(Base, Sub1, Sub2, Main) as module:
+            parser = ArgumentParser(exit_on_error=False, logger={'level': 'DEBUG'})
+            parser.add_argument('--config', action=ActionConfigFile)
+            parser.add_subclass_arguments(Main, 'main')
+            parser.set_defaults(main=lazy_instance(Main))
+            for c in [1, 2]:
+                subconfigs[c] = {
+                    'sub': {
+                        'class_path': f'{module}.Sub{c}',
+                        'init_args': {f's{c}': c},
+                    }
+                }
+                configs[c] = {'main': {'class_path': f'{module}.Main','init_args': subconfigs[c],}}
+                config_paths[c] = Path(f'config{c}.yaml')
+                config_paths[c].write_text(yaml.safe_dump(configs[c]))
+
+            with self.assertLogs(logger=parser.logger, level='DEBUG') as log:
+                cfg = parser.parse_args([f'--config={config_paths[1]}', f'--config={config_paths[2]}'])
+            init = parser.instantiate_classes(cfg)
+            self.assertIsInstance(init.main, Main)
+            self.assertTrue(init.main.sub['init_args']['s2'], 2)
+            self.assertTrue(any("discarding init_args: {'s1': 1}" in o for o in log.output))
 
 @dataclasses.dataclass(frozen=True)
 class MyDataClassA:


### PR DESCRIPTION
## What does this PR do?

Fixes #247 

While a ``subclass_spec`` can be either a ``dict`` or ``Namespace`` 
https://github.com/omni-us/jsonargparse/blob/ac790ba09bcc920cab1acf712422152b931d337a/jsonargparse/typehints.py#L790-L795
when entering ``ActionTypeHint.discard_init_args_on_class_path_change``:
https://github.com/omni-us/jsonargparse/blob/ac790ba09bcc920cab1acf712422152b931d337a/jsonargparse/typehints.py#L295-L310


``jsonargparse.typehints.discard_init_args_on_class_path_change`` below currently assumes any previous value for a nested subclass will already have been cast as a ``Namespace``: 
https://github.com/omni-us/jsonargparse/blob/ac790ba09bcc920cab1acf712422152b931d337a/jsonargparse/typehints.py#L934-L942

with ``L941`` resulting in:
```
argparse.ArgumentError: Parser key "some_class":
  Problem with given class_path '__main__.CustomModule':
    - 'dict' object has no attribute 'init_args'
```
Right now, nested generic ``dict`` configurations like the repro case I include below don't trigger the ``subclass_spec_as_namespace`` ``Namespace`` wrapping that ``jsonargparse.typehints.discard_init_args_on_class_path_change`` requires when removing overridden subclass spec configuration in this context.

With this PR's minor patch to ``jsonargparse.typehints.discard_init_args_on_class_path_change``, this use case can be accommodated. This PR also adds a test that covers the expanded support.
```
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
