### PR TITLE
Fix failure with dataclasses that have field with init=False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,12 +17,13 @@ v4.20.1 (2023-03-??)
 
 Fixed
 ^^^^^
-- Allow ``discard_init_args_on_class_path_change`` to handle more nested contexts `#247
-  <https://github.com/omni-us/jsonargparse/issues/247>`__.
-
 - Dump not working for partial callable with return instance
   `pytorch-lightning#15340 (comment)
   <https://github.com/Lightning-AI/lightning/issues/15340#issuecomment-1439203008>`__.
+- Allow ``discard_init_args_on_class_path_change`` to handle more nested
+  contexts `#247 <https://github.com/omni-us/jsonargparse/issues/247>`__.
+- Failure with dataclasses that have field with ``init=False`` `#252
+  <https://github.com/omni-us/jsonargparse/issues/252>`__.
 
 
 v4.20.0 (2023-02-20)

--- a/jsonargparse/signatures.py
+++ b/jsonargparse/signatures.py
@@ -416,14 +416,15 @@ class SignatureArguments(LoggerProperty):
         added_args: List[str] = []
         params = {p.name: p for p in get_signature_parameters(theclass, None, logger=self.logger)}
         for field in dataclasses.fields(theclass):
-            self._add_signature_parameter(
-                group,
-                nested_key,
-                params[field.name],
-                added_args,
-                fail_untyped=fail_untyped,
-                default=defaults.get(field.name, inspect_empty),
-            )
+            if field.name in params:
+                self._add_signature_parameter(
+                    group,
+                    nested_key,
+                    params[field.name],
+                    added_args,
+                    fail_untyped=fail_untyped,
+                    default=defaults.get(field.name, inspect_empty),
+                )
 
         return added_args
 

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -1615,6 +1615,19 @@ class DataclassesTests(unittest.TestCase):
         self.assertRaises(ArgumentError, lambda: parser.parse_args([]))
 
 
+    def test_dataclass_field_init_false(self):
+
+        @dataclasses.dataclass
+        class DataInitFalse:
+            p1: str = '-'
+            p2: str = dataclasses.field(init=False)
+
+        parser = ArgumentParser(exit_on_error=False)
+        added = parser.add_dataclass_arguments(DataInitFalse, 'd')
+        self.assertEqual(added, ['d.p1'])
+        self.assertEqual(parser.get_defaults(), Namespace(d=Namespace(p1='-')))
+
+
     def test_dataclass_field_default_factory(self):
 
         @dataclasses.dataclass


### PR DESCRIPTION
## What does this PR do?

Fixes #252.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
