### PR TITLE
Include enum members in error when invalid value is given

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Changed
 ^^^^^^^
 - Switched from ``setup.cfg`` to ``pyproject.toml`` for configuration.
 - Removed ``build_sphinx`` from ``setup.py`` and documented how to build.
+- Include enum members in error when invalid value is given
+  `pytorch-lightning#17247
+  <https://github.com/Lightning-AI/lightning/issues/17247>`__.
 
 
 v4.20.1 (2023-03-30)

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -611,12 +611,12 @@ def adapt_typehints(
                 val = val.name
             else:
                 if val not in typehint.__members__:
-                    raise_unexpected_value(f'Expected a member of {typehint}', val)
+                    raise_unexpected_value(f'Expected a member of {typehint}: {iter_to_set_str(typehint.__members__)}', val)
         elif not serialize and not isinstance(val, typehint):
             try:
                 val = typehint[val]
             except KeyError as ex:
-                raise_unexpected_value(f'Expected a member of {typehint}', val, ex)
+                raise_unexpected_value(f'Expected a member of {typehint}: {iter_to_set_str(typehint.__members__)}', val, ex)
 
     # Type
     elif typehint in {Type, type} or typehint_origin in {Type, type}:


### PR DESCRIPTION
## What does this PR do?

Better error message to guide users what to do when they get this error.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
