### PR TITLE
Fix str parameter in subclass incorrectly parsed as dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,13 +15,18 @@ paths are considered internals and can change in minor and patch releases.
 v4.21.0 (2023-04-??)
 --------------------
 
+Fixed
+^^^^^
+- `str` parameter in subclass incorrectly parsed as dict with implicit `null`
+  value (`#262 <https://github.com/omni-us/jsonargparse/issues/262>`__).
+
 Changed
 ^^^^^^^
 - Switched from ``setup.cfg`` to ``pyproject.toml`` for configuration.
 - Removed ``build_sphinx`` from ``setup.py`` and documented how to build.
 - Include enum members in error when invalid value is given
-  `pytorch-lightning#17247
-  <https://github.com/Lightning-AI/lightning/issues/17247>`__.
+  (`pytorch-lightning#17247
+  <https://github.com/Lightning-AI/lightning/issues/17247>`__).
 
 
 v4.20.1 (2023-03-30)

--- a/jsonargparse/loaders_dumpers.py
+++ b/jsonargparse/loaders_dumpers.py
@@ -56,10 +56,13 @@ def yaml_load(stream):
         value = stream
     else:
         value = yaml.load(stream, Loader=DefaultLoader)
-    if isinstance(value, dict) and all(v is None for v in value.values()):
-        keys = {k for k in regex_curly_comma.split(stream) if k}
-        if len(keys) > 0 and keys == set(value.keys()):
+    if isinstance(value, dict) and value and all(v is None for v in value.values()):
+        if len(value) == 1 and stream.strip() == next(iter(value.keys())) + ':':
             value = stream
+        else:
+            keys = {k for k in regex_curly_comma.split(stream) if k}
+            if len(keys) > 0 and keys == set(value.keys()):
+                value = stream
     return value
 
 

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -11,6 +11,7 @@ import yaml
 from jsonargparse import ActionConfigFile, ArgumentParser, set_dumper, set_loader
 from jsonargparse._common import parser_context
 from jsonargparse.loaders_dumpers import load_value, loaders, yaml_dump
+from jsonargparse_tests.base import mock_module
 
 
 class LoadersTests(unittest.TestCase):
@@ -34,6 +35,18 @@ class LoadersTests(unittest.TestCase):
         parser.add_argument('--val', type=str)
         self.assertEqual('{one}', parser.parse_args(['--val={one}']).val)
         self.assertEqual('{one,two,three}', parser.parse_args(['--val={one,two,three}']).val)
+
+
+    def test_disable_implicit_null(self):
+        class Bar:
+            def __init__(self, x: str):
+                pass
+
+        with mock_module(Bar):
+            parser = ArgumentParser()
+            parser.add_subclass_arguments(Bar, 'bar')
+            cfg = parser.parse_args(['--bar=Bar', '--bar.x=Foo:'])
+            self.assertEqual('Foo:', cfg.bar.init_args.x)
 
 
     @unittest.skipIf(not find_spec('omegaconf'), 'omegaconf package is required')


### PR DESCRIPTION
## What does this PR do?

Fixes #262.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
