### PR TITLE
Fixed wrong error indentation for subclass in union

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Fixed
 ^^^^^
 - `str` parameter in subclass incorrectly parsed as dict with implicit `null`
   value (`#262 <https://github.com/omni-us/jsonargparse/issues/262>`__).
+- Wrong error indentation for subclass in union (`pytorch-lightning#17254
+  <https://github.com/Lightning-AI/lightning/issues/17254>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/typehints.py
+++ b/jsonargparse/typehints.py
@@ -535,7 +535,8 @@ def raise_unexpected_value(message: str, val: Any = inspect._empty, exception: O
 
 
 def raise_union_unexpected_value(uniontype, val: Any, exceptions: List[Exception]) -> NoReturn:
-    errors = indent_text('- ' + '\n- '.join(map(str, exceptions)))
+    str_exceptions = [indent_text(str(e), first_line=False) for e in exceptions]
+    errors = indent_text('- ' + '\n- '.join(str_exceptions))
     errors = errors.replace(f'. Got value: {val}', '').replace(f' {val} ', ' ')
     subtypes = uniontype.__args__
     raise ValueError(
@@ -770,7 +771,7 @@ def adapt_typehints(
         val = subclass_spec_as_namespace(val, prev_val)
         if not is_subclass_spec(val):
             raise_unexpected_value(
-                f'Not a valid {typehint.__name__}. Got value: {val_input}\n'
+                f'Not a valid subclass of {typehint.__name__}. Got value: {val_input}\n'
                 'Subclass types expect one of:\n'
                 '- a class path (str)\n'
                 '- a dict with class_path entry\n'
@@ -785,8 +786,8 @@ def adapt_typehints(
             val = adapt_class_type(val, serialize, instantiate_classes, sub_add_kwargs, prev_val=prev_val)
         except (ImportError, AttributeError, AssertionError, ArgumentError) as ex:
             class_path = val if isinstance(val, str) else val['class_path']
-            error = indent_text(f'\n- {ex}')
-            raise_unexpected_value(f'Problem with given class_path {class_path!r}:{error}', exception=ex)
+            error = indent_text(str(ex))
+            raise_unexpected_value(f'Problem with given class_path {class_path!r}:\n{error}', exception=ex)
 
     return val
 

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -333,8 +333,13 @@ def iter_to_set_str(val, sep=','):
     return '{'+sep.join(str(x) for x in val)+'}'
 
 
-def indent_text(text: str) -> str:
-    return textwrap.indent(text, '  ')
+def indent_text(text: str, first_line: bool = True) -> str:
+    if first_line:
+        return textwrap.indent(text, '  ')
+    lines = text.splitlines()
+    if len(lines) == 1:
+        return text
+    return lines[0] + os.linesep + textwrap.indent(os.linesep.join(lines[1:]), '  ')
 
 
 def get_private_kwargs(data, **kwargs):


### PR DESCRIPTION
## What does this PR do?

Fixes error indentation for clarity as proposed in https://github.com/lightning-AI/lightning/issues/17254#issuecomment-1498479901

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
