### PR TITLE
Nested dataclass types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ v4.21.0 (2023-04-??)
 
 Added
 ^^^^^
+- Support for dataclasses nested in a type.
 - Support for pydantic models and attr defines similar to dataclasses.
 
 Fixed
@@ -27,6 +28,7 @@ Fixed
   <https://github.com/Lightning-AI/lightning/issues/17254>`__).
 - ``dataclass`` from pydantic not working (`#100 (comment)
   <https://github.com/omni-us/jsonargparse/issues/100#issuecomment-1408413796>`__).
+- ``add_dataclass_arguments`` not forwarding ``sub_configs`` parameter.
 
 Changed
 ^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -430,18 +430,17 @@ Some notes about this support are:
   config files and environment variables, tuples and sets are represented as an
   array.
 
-- ``dataclasses`` are supported as a type but only for pure data classes and not
-  nested in a type. By pure it is meant that the class only inherits from data
-  classes. Not a mixture of normal classes and data classes. Data classes as
-  fields of other data classes is supported. Pydantic's ``dataclass`` decorator
-  and ``BaseModel`` classes, and attrs' ``define`` decorator are supported
-  like standard dataclasses. Though, this support is currently experimental.
-
 - To set a value to ``None`` it is required to use ``null`` since this is how
   json/yaml defines it. To avoid confusion in the help, ``NoneType`` is
   displayed as ``null``. For example a function argument with type and default
   ``Optional[str] = None`` would be shown in the help as ``type: Union[str,
   null], default: null``.
+
+- ``dataclasses`` are supported even when nested. Final classes, attrs'
+  ``define`` decorator, and pydantic's ``dataclass`` decorator and ``BaseModel``
+  classes are supported and behave like standard dataclasses. If a dataclass
+  inherits from a normal class, the type is considered a subclass instead of a
+  dataclass, see :ref:`sub-classes`.
 
 - Normal classes can be used as a type, which are specified with a dict
   containing ``class_path`` and optionally ``init_args``.

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -1,8 +1,11 @@
+import dataclasses
+import inspect
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Optional, Union
 
 from .namespace import Namespace
+from .optionals import attrs_support, import_attrs, import_pydantic, pydantic_support
 from .type_checking import ArgumentParser
 
 parent_parser: ContextVar['ArgumentParser'] = ContextVar('parent_parser')
@@ -33,3 +36,34 @@ def parser_context(**kwargs):
     finally:
         for context_var, token in context_var_tokens:
             context_var.reset(token)
+
+
+def is_subclass(cls, class_or_tuple) -> bool:
+    """Extension of issubclass that supports non-class arguments."""
+    try:
+        return inspect.isclass(cls) and issubclass(cls, class_or_tuple)
+    except TypeError:
+        return False
+
+
+def is_final_class(cls) -> bool:
+    """Checks whether a class is final, i.e. decorated with ``typing.final``."""
+    return getattr(cls, '__final__', False)
+
+
+def is_dataclass_like(cls) -> bool:
+    if not inspect.isclass(cls):
+        return False
+    if is_final_class(cls):
+        return True
+    classes = [c for c in inspect.getmro(cls) if c != object]
+    all_dataclasses = all(dataclasses.is_dataclass(c) for c in classes)
+    if not all_dataclasses and pydantic_support:
+        pydantic = import_pydantic('is_dataclass_like')
+        classes = [c for c in classes if c != pydantic.utils.Representation]
+        all_dataclasses = all(is_subclass(c, pydantic.BaseModel) for c in classes)
+    if not all_dataclasses and attrs_support:
+        attrs = import_attrs('is_dataclass_like')
+        if attrs.has(cls):
+            return True
+    return all_dataclasses

--- a/jsonargparse/actions.py
+++ b/jsonargparse/actions.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-from ._common import parser_context
+from ._common import is_subclass, parser_context
 from .loaders_dumpers import get_loader_exceptions, load_value
 from .namespace import Namespace, split_key, split_key_root
 from .optionals import FilesCompleterMethod, get_config_read_mode
@@ -25,7 +25,6 @@ from .util import (
     get_typehint_origin,
     import_object,
     indent_text,
-    is_subclass,
     iter_to_set_str,
     parse_value_or_config,
 )

--- a/jsonargparse/deprecated.py
+++ b/jsonargparse/deprecated.py
@@ -182,7 +182,7 @@ class ActionEnum:
 
     def __init__(self, **kwargs):
         if 'enum' in kwargs:
-            from .util import is_subclass
+            from ._common import is_subclass
             if not is_subclass(kwargs['enum'], Enum):
                 raise ValueError('Expected enum to be an subclass of Enum.')
             self._type = kwargs['enum']

--- a/jsonargparse/parameter_resolvers.py
+++ b/jsonargparse/parameter_resolvers.py
@@ -10,13 +10,13 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
+from ._common import is_dataclass_like, is_subclass
 from ._stubs_resolver import get_stub_types
 from .optionals import parse_docs
 from .util import (
     ClassFromFunctionBase,
     LoggerProperty,
     get_import_path,
-    is_subclass,
     iter_to_set_str,
     parse_logger,
     unique,
@@ -325,8 +325,7 @@ def get_kwargs_pop_or_get_parameter(node, component, parent, doc_params, log_deb
 
 
 def is_param_subclass_instance_default(param: ParamData) -> bool:
-    from .signatures import is_pure_dataclass
-    if is_pure_dataclass(type(param.default)):
+    if is_dataclass_like(type(param.default)):
         return False
     from .typehints import ActionTypeHint, get_subclass_types
     class_types = get_subclass_types(param.annotation)

--- a/jsonargparse/typing.py
+++ b/jsonargparse/typing.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple, Type, Union
 
+from ._common import is_final_class
 from .optionals import final
 from .util import Path, get_import_path, get_private_kwargs, import_object
 
@@ -325,11 +326,6 @@ def add_type(type_class: Type, uniqueness_key: Optional[Tuple], type_check: Opti
     if type_check is not None:
         kwargs['type_check'] = type_check  # type: ignore
     register_type(type_class, type_class._type, **kwargs)  # type: ignore
-
-
-def is_final_class(cls):
-    """Checks whether a class is final, i.e. decorated with ``final``."""
-    return getattr(cls, '__final__', False)
 
 
 _fail_already_registered = False

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -166,14 +166,6 @@ def read_stdin() -> str:
     return value
 
 
-def is_subclass(cls, class_or_tuple):
-    """Extension of issubclass that supports non-class arguments."""
-    try:
-        return inspect.isclass(cls) and issubclass(cls, class_or_tuple)
-    except TypeError:
-        return False
-
-
 def import_object(name: str):
     """Returns an object in a module given its dot import path."""
     if not isinstance(name, str) or '.' not in name:

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -153,6 +153,17 @@ class SignaturesTests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: parser.add_class_arguments(Class2))
 
 
+    def test_add_class_with_default(self):
+        class Class:
+            def __init__(self, p1: int = 1, p2: str = '-'):
+                pass
+
+        parser = ArgumentParser()
+        parser.add_class_arguments(Class, 'cls', default=lazy_instance(Class, p1=2))
+        defaults = parser.get_defaults()
+        self.assertEqual(defaults, Namespace(cls=Namespace(p1=2, p2='-')))
+
+
     def test_add_class_without_args(self):
         class NoArgs:
             pass


### PR DESCRIPTION
## What does this PR do?

- Adds support for dataclasses nested in a type.
- Fixes add_dataclass_arguments not forwarding sub_configs parameter.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
