### PR TITLE
Add support for pydantic types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Added
 ^^^^^
 - Support for dataclasses nested in a type.
 - Support for pydantic models and attr defines similar to dataclasses.
+- Support for `pydantic types
+  <https://docs.pydantic.dev/usage/types/#pydantic-types>`__.
 
 Fixed
 ^^^^^

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -5,7 +5,6 @@ from contextvars import ContextVar
 from typing import Optional, Union
 
 from .namespace import Namespace
-from .optionals import attrs_support, import_attrs, import_pydantic, pydantic_support
 from .type_checking import ArgumentParser
 
 parent_parser: ContextVar['ArgumentParser'] = ContextVar('parent_parser')
@@ -58,12 +57,13 @@ def is_dataclass_like(cls) -> bool:
         return True
     classes = [c for c in inspect.getmro(cls) if c != object]
     all_dataclasses = all(dataclasses.is_dataclass(c) for c in classes)
+    from .optionals import attrs_support, pydantic_support
     if not all_dataclasses and pydantic_support:
-        pydantic = import_pydantic('is_dataclass_like')
+        import pydantic.utils
         classes = [c for c in classes if c != pydantic.utils.Representation]
         all_dataclasses = all(is_subclass(c, pydantic.BaseModel) for c in classes)
     if not all_dataclasses and attrs_support:
-        attrs = import_attrs('is_dataclass_like')
+        import attrs
         if attrs.has(cls):
             return True
     return all_dataclasses

--- a/jsonargparse/optionals.py
+++ b/jsonargparse/optionals.py
@@ -135,18 +135,6 @@ def import_reconplogger(importer):
     return reconplogger
 
 
-def import_pydantic(importer):
-    with missing_package_raise('pydantic', importer):
-        import pydantic
-    return pydantic
-
-
-def import_attrs(importer):
-    with missing_package_raise('attrs', importer):
-        import attrs
-    return attrs
-
-
 def set_config_read_mode(
     urls_enabled: bool = False,
     fsspec_enabled: bool = False,

--- a/jsonargparse/parameter_resolvers.py
+++ b/jsonargparse/parameter_resolvers.py
@@ -768,11 +768,11 @@ def get_parameters_from_pydantic(
     method_or_property: Optional[str],
     logger: logging.Logger,
 ) -> Optional[ParamList]:
-    from .optionals import import_pydantic, pydantic_support
+    from .optionals import pydantic_support
     if not pydantic_support or method_or_property:
         return None
-    pydantic = import_pydantic('get_parameters_from_pydantic')
-    if not is_subclass(function_or_class, pydantic.BaseModel):
+    from pydantic import BaseModel  # pylint: disable=no-name-in-module
+    if not is_subclass(function_or_class, BaseModel):
         return None
     params = []
     doc_params = parse_docs(function_or_class, None, logger)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -1299,9 +1299,11 @@ class TypeHintsTests(unittest.TestCase):
 
     def test_typehint_serialize_list(self):
         parser = ArgumentParser()
-        action = parser.add_argument('--list', type=Union[PositiveInt, List[PositiveInt]])
-        self.assertEqual([1, 2], action.serialize([PositiveInt(1), PositiveInt(2)]))
-        self.assertRaises(ValueError, lambda: action.serialize([1, -2]))
+        parser.add_argument('--list', type=Union[PositiveInt, List[PositiveInt]])
+        dump = yaml.safe_load(parser.dump(Namespace(list=[1, 2])))
+        self.assertEqual([1, 2], dump['list'])
+        with self.assertRaises(TypeError):
+            parser.dump(Namespace(list=[1, -2]))
 
 
     def test_typehint_serialize_enum(self):
@@ -1311,9 +1313,11 @@ class TypeHintsTests(unittest.TestCase):
             b = 2
 
         parser = ArgumentParser()
-        action = parser.add_argument('--enum', type=Optional[MyEnum])
-        self.assertEqual('b', action.serialize(MyEnum.b))
-        self.assertRaises(ValueError, lambda: action.serialize('x'))
+        parser.add_argument('--enum', type=Optional[MyEnum])
+        dump = yaml.safe_load(parser.dump(Namespace(enum=MyEnum.b)))
+        self.assertEqual('b', dump['enum'])
+        with self.assertRaises(TypeError):
+            parser.dump(Namespace(enum='x'))
 
 
     def test_unsupported_type(self):


### PR DESCRIPTION
## What does this PR do?

When [pydantic types](https://docs.pydantic.dev/usage/types/#pydantic-types) are used as type hints, these are automatically registered so that parsers properly parse and validate them.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
