### PR TITLE
Fix AST resolver dict use in method when dict created with curly braces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.21.1 (2023-04-??)
+--------------------
+
+Fixed
+^^^^^
+- AST resolver not working for dict used in a method when the dict is created
+  using the curly braces syntax.
+
+
 v4.21.0 (2023-04-21)
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1629,9 +1629,8 @@ unrelated to these variables.
 
     class DictUpdateUseInMethod:
         def __init__(self, **kwargs):
-            self._kwargs = dict(p1=1)
-            self._kwargs.update(**kwargs)
-            # Could also be: self._kwargs = dict(p1=1, **kwargs)
+            self._kwargs = dict(p1=1)     # Can also be: self._kwargs = {'p1': 1}
+            self._kwargs.update(**kwargs) # Can also be: self._kwargs = dict(p1=1, **kwargs)
 
         def a_method(self):
             a_callable(**self._kwargs)

--- a/jsonargparse/parameter_resolvers.py
+++ b/jsonargparse/parameter_resolvers.py
@@ -127,11 +127,14 @@ dict_ast = ast.dump(ast_variable_load('dict'))
 
 
 def ast_is_dict_assign(node):
-    return isinstance(node, ast_assign_type) and isinstance(node.value, ast.Call) and ast.dump(node.value.func) == dict_ast
+    return isinstance(node, ast_assign_type) and (
+        isinstance(node.value, ast.Dict) or
+        (isinstance(node.value, ast.Call) and ast.dump(node.value.func) == dict_ast)
+    )
 
 
 def ast_is_dict_assign_with_value(node, value):
-    if ast_is_dict_assign(node):
+    if ast_is_dict_assign(node) and getattr(node.value, 'keywords', None):
         value_dump = ast.dump(value)
         for keyword in [k.value for k in node.value.keywords]:
             if ast.dump(keyword) == value_dump:

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -126,7 +126,7 @@ class ClassF1:
 
 class ClassF2:
     def __init__(self, **kw):
-        self._ini: Dict[str, Any] = dict(k2=4)
+        self._ini: Dict[str, Any] = {'k2': 4}
         self._ini.update(**kw)
 
     def _run(self):


### PR DESCRIPTION
## What does this PR do?

See title.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
