### PR TITLE
Fix argument links applied on parse silently ignored when the source validation fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Fixed
 ^^^^^
 - Failure for nested argument in optional dataclass type (`#289
   <https://github.com/omni-us/jsonargparse/issues/289>`__).
+- Argument links applied on parse silently ignored when the source validation
+  fails.
 
 
 v4.21.1 (2023-05-09)

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -92,7 +92,9 @@ def test_on_parse_add_class_arguments(subtests):
     parser = parser_classes_links_on_parse()
 
     with subtests.test("without defaults"):
-        assert Namespace() == parser.parse_args([], defaults=False)
+        with pytest.raises(ArgumentError) as ctx:
+            parser.parse_args([], defaults=False)
+        ctx.match('Key "a.v2" not found')
 
     with subtests.test("no arguments"):
         cfg = parser.parse_args([])


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/master/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
