### PR TITLE
class_from_function now supports func_return parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ v4.22.0 (2023-06-??)
 Added
 ^^^^^
 - Parameters that receive a path now also accept ``os.PathLike`` type.
+- ``class_from_function`` now supports ``func_return`` parameter to specify the
+  return type of the function (`lightning-flash#1564 comment
+  <https://github.com/Lightning-Universe/lightning-flash/pull/1564#discussion_r1218147330>`__).
 
 Fixed
 ^^^^^

--- a/jsonargparse/util.py
+++ b/jsonargparse/util.py
@@ -361,13 +361,18 @@ class ClassFromFunctionBase:
 ClassType = TypeVar("ClassType")
 
 
-def class_from_function(func: Callable[..., ClassType]) -> Type[ClassType]:
+def class_from_function(
+    func: Callable[..., ClassType],
+    func_return: Optional[Type[ClassType]] = None,
+) -> Type[ClassType]:
     """Creates a dynamic class which if instantiated is equivalent to calling func.
 
     Args:
-        func: A function that returns an instance of a class. It must have a return type annotation.
+        func: A function that returns an instance of a class.
+        func_return: The return type of the function. Required if func does not have a return type annotation.
     """
-    func_return = inspect.signature(func).return_annotation
+    if func_return is None:
+        func_return = inspect.signature(func).return_annotation
     if isinstance(func_return, str):
         caller_frame = inspect.currentframe().f_back  # type: ignore
         func_return = caller_frame.f_locals.get(func_return) or caller_frame.f_globals.get(func_return)  # type: ignore

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -596,6 +596,16 @@ def test_invalid_class_from_function():
     ctx.match("Unable to dereference None the return type")
 
 
+def get_random_untyped():
+    return Random()
+
+
+def test_class_from_function_given_return_type():
+    cls = class_from_function(get_random_untyped, Random)
+    assert issubclass(cls, Random)
+    assert isinstance(cls(), Random)
+
+
 def get_calendar(a1: str, a2: int = 2) -> Calendar:
     """Returns instance of Calendar"""
     cal = Calendar()


### PR DESCRIPTION
## What does this PR do?

Implements [lightning-flash#1564](https://github.com/Lightning-Universe/lightning-flash/pull/1564#discussion_r1218147330) so that later lightning-flash can be fixed removing duplicated code and only using public API.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
