### PR TITLE
Fix class_from_function not failing when return annotation is missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.22.0 (2023-07-??)
+v4.22.1 (2023-07-??)
 --------------------
 
 Fixed
 ^^^^^
 - Parameter without default and type optional incorrectly added as a required
   argument (`#312 <https://github.com/omni-us/jsonargparse/issues/312>`__).
+- ``class_from_function`` not failing when return annotation is missing.
 
 
 v4.22.0 (2023-06-23)

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -375,6 +375,8 @@ def class_from_function(
     """
     if func_return is None:
         func_return = inspect.signature(func).return_annotation
+    if func_return is inspect.Signature.empty:
+        raise ValueError(f"{func} does not have a return type annotation")
     if isinstance(func_return, str):
         try:
             func_return = get_type_hints(func)["return"]

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -534,7 +534,7 @@ def test_get_params_kwargs_use_in_property():
 
 
 def test_get_params_class_from_function():
-    class_a = class_from_function(function_return_class_c)
+    class_a = class_from_function(function_return_class_c, ClassC)
     params = get_params(class_a)
     assert_params(params, ["pk1", "k2", "pkb1", "kb2", "ka1"])
     with source_unavailable():

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -632,6 +632,16 @@ def test_add_class_from_function_arguments(parser):
     assert init.a.a2 == 3
 
 
+def without_return_type():
+    pass
+
+
+def test_class_from_function_missing_return():
+    with pytest.raises(ValueError) as ctx:
+        class_from_function(without_return_type)
+    ctx.match("does not have a return type annotation")
+
+
 # other tests
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
