### PR TITLE
Fix help print for parsers that have a link target lacking type and help

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Fixed
   incorrectly shown as tuple in help.
 - When all arguments of a group are derived from links, a config load option is
   incorrectly shown in help.
+- Printing help fails for parsers that have a link whose target is an argument
+  lacking type and help.
 
 
 v4.22.0 (2023-06-23)

--- a/jsonargparse/_link_arguments.py
+++ b/jsonargparse/_link_arguments.py
@@ -6,6 +6,7 @@ from argparse import Action as ArgparseAction
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
+from importlib import import_module
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 from ._actions import (
@@ -200,6 +201,8 @@ class ActionLink(Action):
         else:
             type_attr = getattr(self.target[1], "_typehint", self.target[1].type)
             help_str = self.target[1].help
+            if help_str == import_module("jsonargparse._formatters").empty_help:
+                help_str = f"Target argument '{self.target[1].dest}' lacks type and help"
 
         super().__init__(
             [link_str],

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -19,6 +19,14 @@ from jsonargparse_tests.conftest import get_parser_help
 # tests for links applied on parse
 
 
+def test_on_parse_help_target_lacking_type_and_help(parser):
+    parser.add_argument("--a")
+    parser.add_argument("--b")
+    parser.link_arguments("a", "b")
+    help_str = get_parser_help(parser)
+    assert "Target argument 'b' lacks type and help" in help_str
+
+
 def test_on_parse_compute_fn_single_arguments(parser, subtests):
     def a_prod(a):
         return a["v1"] * a["v2"]


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
