### PR TITLE
Fix invalid environment variable names when env_prefix is derived from a prog containing dashes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.22.2 (2023-07-??)
+--------------------
+
+Fixed
+^^^^^
+- Invalid environment variable names when ``env_prefix`` is derived from
+  a ``prog`` containing dashes.
+
+
 v4.22.1 (2023-07-07)
 --------------------
 

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -258,7 +258,7 @@ def get_env_var(
         parser = parser_or_formatter
     env_var = ""
     if isinstance(parser.env_prefix, str):
-        env_var = parser.env_prefix + "_"
+        env_var = parser.env_prefix.replace("-", "_") + "_"
     if action:
         env_var += action.dest
     env_var = env_var.replace(".", "__").upper()

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -26,6 +26,7 @@ from jsonargparse import (
     set_config_read_mode,
     strip_meta,
 )
+from jsonargparse._formatters import get_env_var
 from jsonargparse._optionals import jsonnet_support, jsonschema_support, ruyaml_support
 from jsonargparse.typing import Path_fc, Path_fr, path_type
 from jsonargparse_tests.conftest import (
@@ -151,6 +152,12 @@ def test_parse_object_nested(parser):
     parser.add_argument("--l1.l2.op", type=float)
     assert parser.parse_object({"l1": {"l2": {"op": 2.1}}}).l1.l2.op == 2.1
     pytest.raises(ArgumentError, lambda: parser.parse_object({"l1": {"l2": {"op": "x"}}}))
+
+
+def test_env_prefix_from_prog_with_dashes():
+    parser = ArgumentParser(prog="cli-name")
+    action = parser.add_argument("--arg")
+    assert get_env_var(parser, action) == "CLI_NAME_ARG"
 
 
 def test_parse_env_simple():


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
