### PR TITLE
Subcommands main parser help changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.22.2 (2023-07-??)
+v4.23.0 (2023-07-??)
 --------------------
 
 Fixed
@@ -24,6 +24,14 @@ Fixed
 - ``typing.Literal`` types skipped on python 3.9 when typing_extensions is
   installed (`lightning#18125 comment
   <https://github.com/Lightning-AI/lightning/pull/18125#issuecomment-1644797707>`__).
+
+Changed
+^^^^^^^
+- Subcommands main parser help changes:
+    - Set notation of subcommands choices now only included in usage.
+    - In subcommands section, now each subcommand is always shown separately,
+      including the name, and if available aliases and help.
+    - When ``default_env=True`` include subcommand environment variable name.
 
 
 v4.22.1 (2023-07-07)

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -595,10 +595,11 @@ class _ActionSubCommands(_SubParsersAction):
 
         # create a pseudo-action to hold the choice help
         aliases = kwargs.pop("aliases", ())
+        help_arg = None
         if "help" in kwargs:
             help_arg = kwargs.pop("help")
-            choice_action = self._ChoicesPseudoAction(name, aliases, help_arg)
-            self._choices_actions.append(choice_action)
+        choice_action = self._ChoicesPseudoAction(name, aliases, help_arg)
+        self._choices_actions.append(choice_action)
 
         # add the parser to the name-parser map
         self._name_parser_map[name] = parser

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -99,7 +99,12 @@ class DefaultHelpFormatter(HelpFormatter):
 
     def _format_action_invocation(self, action: Action) -> str:
         parser = parent_parser.get()
-        if not (parser.default_env and action.option_strings):
+        if isinstance(action, _ActionSubCommands):
+            value = "Available subcommands:"
+            if parser.default_env:
+                value = f"ENV:   {get_env_var(self, action)}\n\n  {value}"
+            return value
+        if action.option_strings == [] or not parser.default_env:
             return super()._format_action_invocation(action)
         extr = ""
         if not isinstance(action, (_ActionHelpClassPath, _ActionPrintConfig, _HelpAction)):

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -15,7 +15,7 @@ from jsonargparse import (
     Namespace,
     strip_meta,
 )
-from jsonargparse_tests.conftest import get_parse_args_stdout
+from jsonargparse_tests.conftest import get_parse_args_stdout, get_parser_help
 
 
 @pytest.fixture
@@ -79,6 +79,13 @@ def test_subcommands_parse_args_basics(subcommands_parser):
     cfg = subcommands_parser.parse_args(["b"])
     assert cfg["subcommand"] == "b"
     assert "a" not in cfg
+
+
+def test_main_subcommands_help(subcommands_parser):
+    help_str = get_parser_help(subcommands_parser)
+    assert help_str.count("{a,b,B}") == 1
+    assert "Available subcommands:" in help_str
+    assert "b (B)" in help_str
 
 
 def test_subcommands_parse_args_alias(subcommands_parser):
@@ -161,6 +168,12 @@ def test_subcommands_parse_env(subcommands_parser):
     assert cfg["o1"] == "o1_env"
     assert cfg["subcommand"] == "a"
     assert cfg["a"] == {"ap1": "ap1_env", "ao1": "ao1_env"}
+
+
+def test_subcommands_help_default_env_true(subcommands_parser):
+    subcommands_parser.default_env = True
+    help_str = get_parser_help(subcommands_parser)
+    assert "ENV:   APP_SUBCOMMAND" in help_str
 
 
 def test_subcommand_required_false(parser, subparser):


### PR DESCRIPTION
## What does this PR do?

- Set notation of subcommands choices now only included in usage.
- In subcommands section, now each subcommand is always shown separately, including the name, and if available aliases and help.
- When default_env=True include subcommand environment variable name.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
