### PR TITLE
Add new method ArgumentParser.add_instantiator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Added
   <https://github.com/omni-us/jsonargparse/issues/337#issuecomment-1665055459>`__).
 - Improved resolving of nested forward references in types.
 - The ``ext_vars`` for an ``ActionJsonnet`` argument can now have a default.
+- New method ``ArgumentParser.add_instantiator`` that enables developers to
+  implement custom instantiation (`#170
+  <https://github.com/omni-us/jsonargparse/issues/170>`__).
 
 Deprecated
 ^^^^^^^^^^

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-from ._common import is_subclass, parser_context
+from ._common import get_class_instantiator, is_subclass, parser_context
 from ._loaders_dumpers import get_loader_exceptions, load_value
 from ._namespace import Namespace, split_key, split_key_root
 from ._optionals import FilesCompleterMethod, get_config_read_mode
@@ -324,7 +324,8 @@ class _ActionConfigLoad(Action):
         return self._load_config(value, parser)
 
     def instantiate_classes(self, value):
-        return self.basetype(**value)
+        instantiator_fn = get_class_instantiator()
+        return instantiator_fn(self.basetype, **value)
 
 
 class _ActionHelpClassPath(Action):

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -1,17 +1,36 @@
 import dataclasses
 import inspect
+import sys
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Optional, Union
+from typing import Dict, Optional, Tuple, Type, TypeVar, Union
 
 from ._namespace import Namespace
 from ._type_checking import ArgumentParser
+
+ClassType = TypeVar("ClassType")
+
+if sys.version_info < (3, 8):
+    from typing import Callable
+
+    InstantiatorCallable = Callable[..., ClassType]
+else:
+    from typing import Protocol
+
+    class InstantiatorCallable(Protocol):
+        def __call__(self, class_type: Type[ClassType], *args, **kwargs) -> ClassType:
+            pass  # pragma: no cover
+
+
+InstantiatorsDictType = Dict[Tuple[type, bool], InstantiatorCallable]
+
 
 parent_parser: ContextVar["ArgumentParser"] = ContextVar("parent_parser")
 parser_capture: ContextVar[bool] = ContextVar("parser_capture", default=False)
 defaults_cache: ContextVar[Optional[Namespace]] = ContextVar("defaults_cache", default=None)
 lenient_check: ContextVar[Union[bool, str]] = ContextVar("lenient_check", default=False)
 load_value_mode: ContextVar[Optional[str]] = ContextVar("load_value_mode", default=None)
+class_instantiators: ContextVar[Optional[InstantiatorsDictType]] = ContextVar("class_instantiators")
 
 
 parser_context_vars = dict(
@@ -20,6 +39,7 @@ parser_context_vars = dict(
     defaults_cache=defaults_cache,
     lenient_check=lenient_check,
     load_value_mode=load_value_mode,
+    class_instantiators=class_instantiators,
 )
 
 
@@ -70,3 +90,25 @@ def is_dataclass_like(cls) -> bool:
         if attrs.has(cls):
             return True
     return all_dataclasses
+
+
+def default_class_instantiator(class_type: Type[ClassType], *args, **kwargs) -> ClassType:
+    return class_type(*args, **kwargs)
+
+
+class ClassInstantiator:
+    def __init__(self, instantiators: InstantiatorsDictType) -> None:
+        self.instantiators = instantiators
+
+    def __call__(self, class_type: Type[ClassType], *args, **kwargs) -> ClassType:
+        for (cls, subclasses), instantiator in self.instantiators.items():
+            if class_type is cls or (subclasses and is_subclass(class_type, cls)):
+                return instantiator(class_type, *args, **kwargs)
+        return default_class_instantiator(class_type, *args, **kwargs)
+
+
+def get_class_instantiator() -> InstantiatorCallable:
+    instantiators = class_instantiators.get()
+    if not instantiators:
+        return default_class_instantiator
+    return ClassInstantiator(instantiators)

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
 from ._actions import _ActionConfigLoad
-from ._common import is_dataclass_like, is_subclass
+from ._common import get_class_instantiator, is_dataclass_like, is_subclass
 from ._optionals import get_doc_short_description, pydantic_support
 from ._parameter_resolvers import (
     ParamData,
@@ -558,7 +558,8 @@ def group_instantiate_class(group, cfg):
         value = {}
         parent = cfg
         key = group.dest
-    parent[key] = group.group_class(**value)
+    instantiator_fn = get_class_instantiator()
+    parent[key] = instantiator_fn(group.group_class, **value)
 
 
 def strip_title(value):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -42,7 +42,7 @@ from ._actions import (
     _is_action_value_list,
     remove_actions,
 )
-from ._common import is_dataclass_like, is_subclass, parent_parser, parser_context
+from ._common import get_class_instantiator, is_dataclass_like, is_subclass, parent_parser, parser_context
 from ._loaders_dumpers import (
     get_loader_exceptions,
     load_value,
@@ -1044,13 +1044,16 @@ def adapt_class_type(value, serialize, instantiate_classes, sub_add_kwargs, prev
             if init_args:
                 value["init_args"] = init_args
             return value
+
+        instantiator_fn = get_class_instantiator()
+
         if skip_args:
 
             def partial_instance(*args):
-                return val_class(*args, **{**init_args, **dict_kwargs})
+                return instantiator_fn(val_class, *args, **{**init_args, **dict_kwargs})
 
             return partial_instance
-        return val_class(**{**init_args, **dict_kwargs})
+        return instantiator_fn(val_class, **{**init_args, **dict_kwargs})
 
     prev_init_args = prev_val.get("init_args") if isinstance(prev_val, Namespace) else None
 

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -26,12 +26,11 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union,
     get_type_hints,
 )
 
-from ._common import is_subclass, parser_capture, parser_context
+from ._common import ClassType, is_subclass, parser_capture, parser_context
 from ._deprecated import PathDeprecations
 from ._loaders_dumpers import json_dump, load_value
 from ._optionals import (
@@ -358,9 +357,6 @@ def known_to_fsspec(path: str) -> bool:
 
 class ClassFromFunctionBase:
     wrapped_function: Callable
-
-
-ClassType = TypeVar("ClassType")
 
 
 def class_from_function(

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -379,6 +379,20 @@ def test_add_class_docstring_parse_fail(parser, logger):
     assert "a1 description" not in help_str
 
 
+def test_add_class_custom_instantiator(parser):
+    def instantiate(cls, **kwargs):
+        instance = cls(**kwargs)
+        instance.call = "custom"
+        return instance
+
+    parser.add_class_arguments(Class0, "a")
+    parser.add_instantiator(instantiate, Class0)
+    cfg = parser.parse_args([])
+    init = parser.instantiate_classes(cfg)
+    assert isinstance(init.a, Class0)
+    assert init.a.call == "custom"
+
+
 # add_method_arguments tests
 
 


### PR DESCRIPTION
## What does this PR do?

By having an `add_instantiator` method, developers can override the default implementation to have a custom instantiation or run some code before/after instantiation.

Fixes #170.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
