### PR TITLE
Fix inconsistent ARG and missing ENV in help when default_env=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 - Invalid environment variable names when ``env_prefix`` is derived from
   a ``prog`` containing dashes.
 - Pylance unable to resolve types from ``jsonargparse.typing``.
+- Inconsistent ``ARG:`` and missing ``ENV:`` in help when ``default_env=True``.
 
 
 v4.22.1 (2023-07-07)

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -17,6 +17,8 @@ from ._actions import (
     ActionConfigFile,
     ActionYesNo,
     _ActionConfigLoad,
+    _ActionHelpClassPath,
+    _ActionPrintConfig,
     _ActionSubCommands,
     _find_action,
     filter_default_actions,
@@ -97,10 +99,10 @@ class DefaultHelpFormatter(HelpFormatter):
 
     def _format_action_invocation(self, action: Action) -> str:
         parser = parent_parser.get()
-        if action.option_strings == [] or action.default == SUPPRESS or not parser.default_env:
+        if not (parser.default_env and action.option_strings):
             return super()._format_action_invocation(action)
         extr = ""
-        if parser.default_env:
+        if not isinstance(action, (_ActionHelpClassPath, _ActionPrintConfig, _HelpAction)):
             extr += "\n  ENV:   " + get_env_var(self, action)
         return "ARG:   " + super()._format_action_invocation(action) + extr
 

--- a/jsonargparse_tests/test_formatters.py
+++ b/jsonargparse_tests/test_formatters.py
@@ -14,13 +14,20 @@ def parser() -> ArgumentParser:
     return ArgumentParser(prog="app", default_env=True)
 
 
+def test_help_basics(parser):
+    help_str = get_parser_help(parser)
+    assert "ARG:   -h, --help" in help_str
+    assert "APP_HELP" not in help_str
+
+
 def test_help_action_config_file(parser):
     parser.add_argument("-c", "--cfg", help="Config in yaml/json.", action=ActionConfigFile)
     help_str = get_parser_help(parser)
-    assert "--print_config" in help_str
+    assert "ARG:   --print_config" in help_str
     assert "ARG:   -c CFG, --cfg CFG" in help_str
     assert "ENV:   APP_CFG" in help_str
     assert "Config in yaml/json." in help_str
+    assert "APP_PRINT_CONFIG" not in help_str
 
 
 def test_help_required_and_default(parser):

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -164,6 +164,17 @@ def test_add_class_with_default(parser):
     assert defaults == Namespace(cls=Namespace(p1=2, p2="-"))
 
 
+def test_add_class_env_help(parser):
+    parser.env_prefix = "APP"
+    parser.default_env = True
+    parser.add_class_arguments(WithDefault, "cls")
+    help_str = get_parser_help(parser)
+    assert "ARG:   --cls CONFIG" in help_str
+    assert "ARG:   --cls.p1 P1" in help_str
+    assert "ENV:   APP_CLS\n" in help_str
+    assert "ENV:   APP_CLS__P1" in help_str
+
+
 class NoParams:
     pass
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
