### PR TITLE
Fix Literal types on python 3.9 when typing_extensions is installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Fixed
   a ``prog`` containing dashes.
 - Pylance unable to resolve types from ``jsonargparse.typing``.
 - Inconsistent ``ARG:`` and missing ``ENV:`` in help when ``default_env=True``.
+- ``typing.Literal`` types skipped on python 3.9 when typing_extensions is
+  installed (`lightning#18125 comment
+  <https://github.com/Lightning-AI/lightning/pull/18125#issuecomment-1644797707>`__).
 
 
 v4.22.1 (2023-07-07)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -136,6 +136,14 @@ def test_literal(parser):
         assert value in help_str
 
 
+@pytest.mark.skipif(not Literal, reason="Literal introduced in python 3.8 or backported in typing_extensions")
+def test_union_of_literals(parser):
+    literal_type = __import__("typing").Literal if sys.version_info[:2] == (3, 9) else Literal
+    parser.add_argument("--literal", type=Union[literal_type[1, 2], literal_type["a", "b"]])  # noqa: F821
+    assert "a" == parser.parse_args(["--literal=a"]).literal
+    assert 2 == parser.parse_args(["--literal=2"]).literal
+
+
 def test_type_any(parser):
     parser.add_argument("--any", type=Any)
     assert "abc" == parser.parse_args(["--any=abc"]).any


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning/pull/18125#issuecomment-1644797707

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
