### PR TITLE
Add support for decimal.Decimal as a type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ v4.24.0 (2023-08-??)
 Added
 ^^^^^
 - New option in ``dump`` for including link targets.
+- Support ``decimal.Decimal`` as a type.
 
 
 v4.23.1 (2023-08-04)

--- a/README.rst
+++ b/README.rst
@@ -431,7 +431,7 @@ Some notes about this support are:
   <type>`` instead of ``Union[<type>, <type>]``).
 
 - Fully supported types are: ``str``, ``bool`` (more details in
-  :ref:`boolean-arguments`), ``int``, ``float``, ``complex``,
+  :ref:`boolean-arguments`), ``int``, ``float``, ``Decimal``, ``complex``,
   ``bytes``/``bytearray`` (Base64 encoding), ``range``, ``List`` (more details
   in :ref:`list-append`), ``Iterable``, ``Sequence``, ``Any``, ``Union``,
   ``Optional``, ``Type``, ``Enum``, ``PathLike``, ``UUID``, ``timedelta``,

--- a/jsonargparse/typing.py
+++ b/jsonargparse/typing.py
@@ -360,6 +360,7 @@ Path_drw = path_type("drw", docstring="path to a directory that exists and is re
 
 register_type(os.PathLike, str, str)
 register_type(complex)
+register_type_on_first_use("decimal.Decimal", float)
 register_type_on_first_use("uuid.UUID")
 
 for _path in [pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath]:

--- a/jsonargparse_tests/test_typing.py
+++ b/jsonargparse_tests/test_typing.py
@@ -4,6 +4,7 @@ import pickle
 import random
 import uuid
 from datetime import datetime, timedelta
+from decimal import Decimal
 from typing import List, Optional, Union
 
 import pytest
@@ -357,6 +358,14 @@ def test_register_type_on_first_use():
     registered = get_registered_type(RegisterOnFirstUse)
     assert registered.type_class is RegisterOnFirstUse
     assert f"{__name__}.RegisterOnFirstUse" not in registration_pending
+
+
+def test_decimal(parser):
+    parser.add_argument("--decimal", type=Decimal)
+    cfg = parser.parse_args(["--decimal=0.1"])
+    assert isinstance(cfg.decimal, Decimal)
+    assert cfg.decimal == Decimal("0.1")
+    assert parser.dump(cfg) == "decimal: 0.1\n"
 
 
 def test_uuid(parser):


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
