### PR TITLE
Deprecate ActionJsonnetExtVars in favor of type=dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,12 @@ Added
 - Resolve types that use ``TYPE_CHECKING`` blocks (`#337 comment
   <https://github.com/omni-us/jsonargparse/issues/337#issuecomment-1665055459>`__).
 - Improved resolving of nested forward references in types.
+- The ``ext_vars`` for an ``ActionJsonnet`` argument can now have a default.
+
+Deprecated
+^^^^^^^^^^
+- ``ActionJsonnetExtVars`` is deprecated and will be removed in v5.0.0. Instead
+  use ``type=dict``.
 
 
 v4.23.1 (2023-08-04)

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -2288,10 +2288,10 @@ dictionary of variables. Its use would be as follows:
 
 .. testcode:: jsonnet
 
-    from jsonargparse import ArgumentParser, ActionJsonnet, ActionJsonnetExtVars
+    from jsonargparse import ArgumentParser, ActionJsonnet
 
     parser = ArgumentParser()
-    parser.add_argument("--in_ext_vars", action=ActionJsonnetExtVars())
+    parser.add_argument("--in_ext_vars", type=dict)
     parser.add_argument("--in_jsonnet", action=ActionJsonnet(ext_vars="in_ext_vars"))
 
 For example, if a jsonnet file required some external variable ``param``, then

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -17,6 +17,7 @@ from ._type_checking import ArgumentParser
 
 __all__ = [
     "ActionEnum",
+    "ActionJsonnetExtVars",
     "ActionOperators",
     "ActionPath",
     "ActionPathList",
@@ -581,3 +582,20 @@ deprecated_module(
         "import_docstring_parse": ("_optionals", "import_docstring_parser"),
     },
 )
+
+
+@deprecated(
+    """
+    ActionJsonnetExtVars was deprecated in v4.24.0 and will be removed in
+    v5.0.0. Instead use ``type=dict``.
+"""
+)
+class ActionJsonnetExtVars:
+    """Action to add argument to provide ext_vars for jsonnet parsing."""
+
+    def __call__(self, *args, **kwargs):
+        from ._typehints import ActionTypeHint
+
+        action = ActionTypeHint(typehint=dict)(**kwargs)
+        action.jsonnet_ext_vars = True
+        return action

--- a/jsonargparse_tests/test_jsonschema.py
+++ b/jsonargparse_tests/test_jsonschema.py
@@ -83,7 +83,7 @@ def parser_schema_object(parser):
         },
         "additionalProperties": False,
     }
-    parser.add_argument("--op2", action=ActionJsonSchema(schema=schema_object))
+    parser.add_argument("--op2", action=ActionJsonSchema(schema=schema_object, with_meta=False))
     parser.add_argument("--cfg", action=ActionConfigFile)
     return parser
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
