### PR TITLE
Fix ActionJsonSchema not setting correctly defaults when schema uses oneOf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Fixed
 - AST resolver ``kwargs.pop()`` with conflicting defaults not setting the
   conditional default (`#362
   <https://github.com/omni-us/jsonargparse/issues/362>`__).
+- ``ActionJsonSchema`` not setting correctly defaults when schema uses
+  ``oneOf``.
 
 
 v4.24.0 (2023-08-23)

--- a/jsonargparse_tests/test_jsonschema.py
+++ b/jsonargparse_tests/test_jsonschema.py
@@ -114,6 +114,37 @@ def test_schema_object_parse_config(parser, tmp_path):
     assert op2_val == cfg["op2"]
 
 
+def test_schema_oneof_add_defaults(parser):
+    schema = {
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": ["x"]},
+                    "pc": {"type": "integer", "default": 1},
+                    "px": {"type": "string", "default": "dx"},
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": ["y"]},
+                    "pc": {"type": "integer", "default": 2},
+                    "py": {"type": "string", "default": "dy"},
+                },
+            },
+        ]
+    }
+    parser.add_argument("--data", action=ActionJsonSchema(schema=schema))
+    parser.add_argument("--cfg", action=ActionConfigFile)
+
+    cfg = parser.parse_args(['--data={"kind": "x"}'])
+    assert cfg.data == {"kind": "x", "pc": 1, "px": "dx"}
+
+    cfg = parser.parse_args(['--data={"kind": "y", "pc": 3}'])
+    assert cfg.data == {"kind": "y", "pc": 3, "py": "dy"}
+
+
 # other tests
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
