### PR TITLE
Fix recommended print_config steps failure when default_config_files is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Fixed
   <https://github.com/omni-us/jsonargparse/issues/362>`__).
 - ``ActionJsonSchema`` not setting correctly defaults when schema uses
   ``oneOf``.
+- Recommended ``print_config`` steps not working when ``default_config_files``
+  used due to the config file initially being empty (`#367
+  <https://github.com/omni-us/jsonargparse/issues/367>`__).
 
 
 v4.24.0 (2023-08-23)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -631,6 +631,8 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
             cfg_dict = load_value(cfg_str, path=cfg_path, ext_vars=ext_vars)
         except get_loader_exceptions() as ex:
             raise TypeError(f"Problems parsing config: {ex}") from ex
+        if cfg_dict is None:
+            return Namespace()
         if not isinstance(cfg_dict, dict):
             raise TypeError(f"Unexpected config: {cfg_str}")
         return self._apply_actions(cfg_dict, prev_cfg=prev_cfg)

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -698,6 +698,15 @@ def test_print_config_invalid_flag(print_parser):
     ctx.match('Invalid option "invalid"')
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 6), reason="not supported in python 3.6")
+def test_print_config_empty_default_config_file(print_parser, tmp_cwd):
+    default_config_file = tmp_cwd / "defaults.yaml"
+    default_config_file.touch()
+    print_parser.default_config_files = [default_config_file]
+    out = get_parse_args_stdout(print_parser, ["--print_config"])
+    assert yaml.safe_load(out) == {"g1": {"v2": "2"}, "g2": {"v3": None}, "v1": 1}
+
+
 def test_default_config_files(parser, subtests, tmp_cwd):
     default_config_file = tmp_cwd / "defaults.yaml"
     default_config_file.write_text("op1: from default config file\n")


### PR DESCRIPTION
## What does this PR do?

Fixes #367

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
