### PR TITLE
better error message when subcommand is not given

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.25.0 (2023-09-??)
+--------------------
+
+Changed
+^^^^^^^
+- Provide a more informative error message to remind user to select
+  and provide a subcommand when a subcommand is required but not
+  provided (`#371<https://github.com/omni-us/jsonargparse/pull/371>`__).
+
 v4.24.1 (2023-09-06)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
   and provide a subcommand when a subcommand is required but not
   provided (`#371<https://github.com/omni-us/jsonargparse/pull/371>`__).
 
+
 v4.24.1 (2023-09-06)
 --------------------
 

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -699,6 +699,25 @@ class _ActionSubCommands(_SubParsersAction):
             if subcommand is None and not (fail_no_subcommand and action._required):  # type: ignore
                 return None, None
             if action._required and subcommand not in action._name_parser_map:  # type: ignore
+                if dest == "subcommand":
+                    # If this action is a subcommand action and no subcommand is provided,
+                    # present the user with a friendly error message to remind them of
+                    # the available subcommands and to select one.
+                    available_subcommands = list(action._name_parser_map.keys())
+                    if len(available_subcommands) < 10:
+                        candidate_subcommands_str = "{" + ",".join(available_subcommands) + "}"
+                    else:
+                        candidate_subcommands_str = (
+                            "{"
+                            + ",".join(available_subcommands[:5])
+                            + ", ..., "
+                            + ",".join(available_subcommands[-5:])
+                            + "}"
+                        )
+                    raise KeyError(
+                        f'expected "subcommand" to be one of {candidate_subcommands_str}, but it was not provided.'
+                    )
+
                 raise KeyError(f'"{dest}" is required but not given or its value is None.')
 
         return subcommand_keys, [action._name_parser_map.get(s) for s in subcommand_keys]  # type: ignore

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -699,26 +699,23 @@ class _ActionSubCommands(_SubParsersAction):
             if subcommand is None and not (fail_no_subcommand and action._required):  # type: ignore
                 return None, None
             if action._required and subcommand not in action._name_parser_map:  # type: ignore
-                if dest == "subcommand":
-                    # If this action is a subcommand action and no subcommand is provided,
-                    # present the user with a friendly error message to remind them of
-                    # the available subcommands and to select one.
-                    available_subcommands = list(action._name_parser_map.keys())
-                    if len(available_subcommands) <= 10:
-                        candidate_subcommands_str = "{" + ",".join(available_subcommands) + "}"
-                    else:
-                        candidate_subcommands_str = (
-                            "{"
-                            + ",".join(available_subcommands[:5])
-                            + ", ..., "
-                            + ",".join(available_subcommands[-5:])
-                            + "}"
-                        )
-                    raise KeyError(
-                        f'expected "subcommand" to be one of {candidate_subcommands_str}, but it was not provided.'
+                # If this action is a subcommand action and no subcommand is provided,
+                # present the user with a friendly error message to remind them of
+                # the available subcommands and to select one.
+                available_subcommands = list(action._name_parser_map.keys())
+                if len(available_subcommands) <= 10:
+                    candidate_subcommands_str = "{" + ",".join(available_subcommands) + "}"
+                else:
+                    candidate_subcommands_str = (
+                        "{"
+                        + ",".join(available_subcommands[:5])
+                        + ", ..., "
+                        + ",".join(available_subcommands[-5:])
+                        + "}"
                     )
-
-                raise KeyError(f'"{dest}" is required but not given or its value is None.')
+                raise KeyError(
+                    f'expected "subcommand" to be one of {candidate_subcommands_str}, but it was not provided.'
+                )
 
         return subcommand_keys, [action._name_parser_map.get(s) for s in subcommand_keys]  # type: ignore
 

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -699,23 +699,15 @@ class _ActionSubCommands(_SubParsersAction):
             if subcommand is None and not (fail_no_subcommand and action._required):  # type: ignore
                 return None, None
             if action._required and subcommand not in action._name_parser_map:  # type: ignore
-                # If this action is a subcommand action and no subcommand is provided,
+                # If subcommand is required and no subcommand is provided,
                 # present the user with a friendly error message to remind them of
                 # the available subcommands and to select one.
                 available_subcommands = list(action._name_parser_map.keys())
-                if len(available_subcommands) <= 10:
+                if len(available_subcommands) <= 5:
                     candidate_subcommands_str = "{" + ",".join(available_subcommands) + "}"
                 else:
-                    candidate_subcommands_str = (
-                        "{"
-                        + ",".join(available_subcommands[:5])
-                        + ", ..., "
-                        + ",".join(available_subcommands[-5:])
-                        + "}"
-                    )
-                raise KeyError(
-                    f'expected "subcommand" to be one of {candidate_subcommands_str}, but it was not provided.'
-                )
+                    candidate_subcommands_str = "{" + ",".join(available_subcommands[:5]) + ", ...}"
+                raise KeyError(f'expected "{dest}" to be one of {candidate_subcommands_str}, but it was not provided.')
 
         return subcommand_keys, [action._name_parser_map.get(s) for s in subcommand_keys]  # type: ignore
 

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -704,7 +704,7 @@ class _ActionSubCommands(_SubParsersAction):
                     # present the user with a friendly error message to remind them of
                     # the available subcommands and to select one.
                     available_subcommands = list(action._name_parser_map.keys())
-                    if len(available_subcommands) < 10:
+                    if len(available_subcommands) <= 10:
                         candidate_subcommands_str = "{" + ",".join(available_subcommands) + "}"
                     else:
                         candidate_subcommands_str = (

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -43,6 +43,25 @@ from jsonargparse_tests.conftest import (
 )
 
 
+@pytest.fixture
+def auto_recover_sys_argv():
+    """With the help of this fixture,
+    a test case that changes the `sys.argv` will not affect other test cases,
+    regardless of whether this test case succeeds or fails.
+
+    This is helpful if we want to use `sys.argv` in pytest for some tests
+    because pytest is its own CLI program with its own CLI handling.
+
+    Example:
+        def test_change_sys_argv(auto_recover_sys_argv):
+            sys.argv = ["foo.py", "--value", "2"]
+            ...
+    """
+    original_sys_argv = sys.argv
+    yield original_sys_argv
+    sys.argv = original_sys_argv
+
+
 def test_parse_args_simple(parser):
     parser.add_argument("--op", type=int)
     assert parser.parse_args(["--op=1"]) == Namespace(op=1)
@@ -58,6 +77,12 @@ def test_parse_args_nested(parser):
 def test_parse_args_unrecognized_arguments(parser):
     err = get_parse_args_stderr(parser, ["--unrecognized"])
     assert "Unrecognized arguments:" in err
+
+
+def test_parse_args_from_sys_argv(parser, auto_recover_sys_argv):
+    parser.add_argument("--op", type=str)
+    sys.argv = ["", "--op", "hello"]
+    assert parser.parse_args() == Namespace(op="hello")
 
 
 def test_parse_args_invalid_args(parser):

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -43,25 +43,6 @@ from jsonargparse_tests.conftest import (
 )
 
 
-@pytest.fixture
-def auto_recover_sys_argv():
-    """With the help of this fixture,
-    a test case that changes the `sys.argv` will not affect other test cases,
-    regardless of whether this test case succeeds or fails.
-
-    This is helpful if we want to use `sys.argv` in pytest for some tests
-    because pytest is its own CLI program with its own CLI handling.
-
-    Example:
-        def test_change_sys_argv(auto_recover_sys_argv):
-            sys.argv = ["foo.py", "--value", "2"]
-            ...
-    """
-    original_sys_argv = sys.argv
-    yield original_sys_argv
-    sys.argv = original_sys_argv
-
-
 def test_parse_args_simple(parser):
     parser.add_argument("--op", type=int)
     assert parser.parse_args(["--op=1"]) == Namespace(op=1)
@@ -79,10 +60,10 @@ def test_parse_args_unrecognized_arguments(parser):
     assert "Unrecognized arguments:" in err
 
 
-def test_parse_args_from_sys_argv(parser, auto_recover_sys_argv):
+def test_parse_args_from_sys_argv(parser):
     parser.add_argument("--op", type=str)
-    sys.argv = ["", "--op", "hello"]
-    assert parser.parse_args() == Namespace(op="hello")
+    with patch("sys.argv", ["", "--op", "hello"]):
+        assert parser.parse_args() == Namespace(op="hello")
 
 
 def test_parse_args_invalid_args(parser):

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -53,8 +53,17 @@ def test_subcommands_undefined_subcommand(subcommands_parser):
     pytest.raises(ArgumentError, lambda: subcommands_parser.parse_args(["c"]))
 
 
-def test_subcommands_missing_required_subcommand(subcommands_parser):
-    pytest.raises(ArgumentError, lambda: subcommands_parser.parse_args())
+def test_subcommands_not_given_when_few_subcommands(subcommands_parser, parser, subparser):
+    err = get_parse_args_stderr(subcommands_parser, [])
+    assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
+
+
+def test_subcommands_not_given_when_many_subcommands(parser, subparser):
+    subcommands = parser.add_subcommands()
+    for subcommand in range(ord("a"), ord("l") + 1):
+        subcommands.add_subcommand(chr(subcommand), subparser)
+    err = get_parse_args_stderr(parser, [])
+    assert "error: 'expected \"subcommand\" to be one of {a,b,c,d,e, ...}, but it was not provided.'" in err
 
 
 def test_subcommands_missing_required_subargument(subcommands_parser):
@@ -287,16 +296,3 @@ def test_subcommands_custom_instantiator(parser, subparser, subtests):
         init = parser.instantiate_classes(cfg)
         assert isinstance(init.cmd.cls, CustomInstantiationBase)
         assert init.cmd.cls.call == "subparser"
-
-
-def test_subcommands_not_give_when_subcommands_le_10(subcommands_parser):
-    err = get_parse_args_stderr(subcommands_parser, [])
-    assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
-
-
-def test_subcommands_not_give_when_subcommands_greater_10(parser, subparser):
-    subcommands = parser.add_subcommands()
-    for subcommand in range(ord("a"), ord("l") + 1):
-        subcommands.add_subcommand(chr(subcommand), subparser)
-    err = get_parse_args_stderr(parser, [])
-    assert "error: 'expected \"subcommand\" to be one of {a,b,c,d,e, ..., h,i,j,k,l}, but it was not provided.'" in err

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -15,7 +15,7 @@ from jsonargparse import (
     Namespace,
     strip_meta,
 )
-from jsonargparse_tests.conftest import get_parse_args_stdout, get_parser_help
+from jsonargparse_tests.conftest import get_parse_args_stderr, get_parse_args_stdout, get_parser_help
 from jsonargparse_tests.test_subclasses import CustomInstantiationBase, instantiator
 
 
@@ -287,3 +287,16 @@ def test_subcommands_custom_instantiator(parser, subparser, subtests):
         init = parser.instantiate_classes(cfg)
         assert isinstance(init.cmd.cls, CustomInstantiationBase)
         assert init.cmd.cls.call == "subparser"
+
+
+def test_subcommands_not_give_when_subcommands_le_10(subcommands_parser):
+    err = get_parse_args_stderr(subcommands_parser, [])
+    assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
+
+
+def test_subcommands_not_give_when_subcommands_greater_10(parser, subparser):
+    subcommands = parser.add_subcommands()
+    for subcommand in range(ord("a"), ord("l") + 1):
+        subcommands.add_subcommand(chr(subcommand), subparser)
+    err = get_parse_args_stderr(parser, [])
+    assert "error: 'expected \"subcommand\" to be one of {a,b,c,d,e, ..., h,i,j,k,l}, but it was not provided.'" in err

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -56,7 +56,6 @@ def test_subcommands_undefined_subcommand(subcommands_parser):
 def test_subcommands_not_given_when_few_subcommands(subcommands_parser, parser, subparser):
     err = get_parse_args_stderr(subcommands_parser, [])
     assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
-    pytest.raises(ArgumentError, lambda: subcommands_parser.parse_args())
 
 
 def test_subcommands_not_given_when_many_subcommands(parser, subparser):

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -53,7 +53,7 @@ def test_subcommands_undefined_subcommand(subcommands_parser):
     pytest.raises(ArgumentError, lambda: subcommands_parser.parse_args(["c"]))
 
 
-def test_subcommands_not_given_when_few_subcommands(subcommands_parser, parser, subparser):
+def test_subcommands_not_given_when_few_subcommands(subcommands_parser):
     err = get_parse_args_stderr(subcommands_parser, [])
     assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
 

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -56,6 +56,7 @@ def test_subcommands_undefined_subcommand(subcommands_parser):
 def test_subcommands_not_given_when_few_subcommands(subcommands_parser, parser, subparser):
     err = get_parse_args_stderr(subcommands_parser, [])
     assert "error: 'expected \"subcommand\" to be one of {a,b,B}, but it was not provided.'" in err
+    pytest.raises(ArgumentError, lambda: subcommands_parser.parse_args())
 
 
 def test_subcommands_not_given_when_many_subcommands(parser, subparser):


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Fix issue: https://github.com/Lightning-AI/lightning/issues/18446

If the parser is configured with subcommands (using `ArgumentParser.add_subcommands`), the `subcommand._subcommands_action` will create an `_ActionSubCommands` object. During `parse_args`, it calls `_parse_common`, which handles the subcommands through `_ActionSubCommands.handle_subcommands`. This function relies on `_ActionSubCommands.get_subcommands` to retrieve subcommand parsers.

Within `_ActionSubCommands.get_subcommands`, if no subcommand was provided, it will raise a KeyError.

To provide a more informative error message, I have added a check here. If this action is a subcommand action, it will raise a KeyError with an error message that reminds users of the available subcommands and prompts them to select one."

<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
