### PR TITLE
fix `parse_args` for `Callable` with multiple input arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Fixed
 - ``--print_config`` fails when parser has shallow links.
 - Argument links unnecessarily applied when ``--print_config`` used and parser
   has subcommands (`#311 <https://github.com/omni-us/jsonargparse/issue/311>`__).
+- ``parse_args`` fails to parse arguments when data type is a ``Callable`` with multiple input arguments
+  (`#372 <https://github.com/omni-us/jsonargparse/issues/372>`__).
 
 Changed
 ^^^^^^^

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -941,10 +941,9 @@ example the classes:
 
 
     class SGD(Optimizer):
-        def __init__(self, params: Iterable, lr: float, momentum: float = 0.):
+        def __init__(self, params: Iterable, lr: float):
             super().__init__(params)
             self.lr = lr
-            self.momentum = momentum
 
 .. testcode:: callable
     :hide:
@@ -958,20 +957,26 @@ A possible parser and callable behavior would be:
     >>> value = {
     ...     "class_path": "SGD",
     ...     "init_args": {
-    ...         "momentum": 0.9,
+    ...         "lr": 0.01,
     ...     },
     ... }
 
-    >>> parser.add_argument("--optimizer", type=Callable[[Iterable, float], Optimizer])  # doctest: +IGNORE_RESULT
+    >>> parser.add_argument("--optimizer", type=Callable[[Iterable], Optimizer])  # doctest: +IGNORE_RESULT
     >>> cfg = parser.parse_args(["--optimizer", str(value)])
     >>> cfg.optimizer
-    Namespace(class_path='__main__.SGD', init_args=Namespace(momentum=0.9))
+    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.01))
     >>> init = parser.instantiate_classes(cfg)
-    >>> optimizer = init.optimizer([1, 2, 3], 0.01)
+    >>> optimizer = init.optimizer([1, 2, 3])
     >>> isinstance(optimizer, SGD)
     True
-    >>> optimizer.params, optimizer.lr, optimizer.momentum
-    ([1, 2, 3], 0.01, 0.9)
+    >>> optimizer.params, optimizer.lr
+    ([1, 2, 3], 0.01)
+
+Multiple dependency injection is also supported and can be specified the same
+way with ``Callable`` type hinting. For example, for two ``Iterable``
+dependencies, you can use the following syntax:
+``Callable[[Iterable, Iterable], Type]``. Please be aware that the injected
+dependencies passed as positional arguments (that is, passed as ``*args``).
 
 .. note::
 
@@ -998,11 +1003,11 @@ Then a parser and behavior could be:
     >>> parser.add_class_arguments(Model, 'model')
     >>> cfg = parser.get_defaults()
     >>> cfg.model.optimizer
-    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.05, momentum=0.0))
+    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.05))
     >>> init = parser.instantiate_classes(cfg)
     >>> optimizer = init.model.optimizer([1, 2, 3])
-    >>> optimizer.params, optimizer.lr, optimizer.momentum
-    ([1, 2, 3], 0.05, 0.0)
+    >>> optimizer.params, optimizer.lr
+    ([1, 2, 3], 0.05)
 
 See :ref:`ast-resolver` for limitations of lambda defaults.
 

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -941,9 +941,10 @@ example the classes:
 
 
     class SGD(Optimizer):
-        def __init__(self, params: Iterable, lr: float):
+        def __init__(self, params: Iterable, lr: float, momentum: float = 0.):
             super().__init__(params)
             self.lr = lr
+            self.momentum = momentum
 
 .. testcode:: callable
     :hide:
@@ -957,20 +958,20 @@ A possible parser and callable behavior would be:
     >>> value = {
     ...     "class_path": "SGD",
     ...     "init_args": {
-    ...         "lr": 0.01,
+    ...         "momentum": 0.9,
     ...     },
     ... }
 
-    >>> parser.add_argument("--optimizer", type=Callable[[Iterable], Optimizer])  # doctest: +IGNORE_RESULT
+    >>> parser.add_argument("--optimizer", type=Callable[[Iterable, float], Optimizer])  # doctest: +IGNORE_RESULT
     >>> cfg = parser.parse_args(["--optimizer", str(value)])
     >>> cfg.optimizer
-    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.01))
+    Namespace(class_path='__main__.SGD', init_args=Namespace(momentum=0.9))
     >>> init = parser.instantiate_classes(cfg)
-    >>> optimizer = init.optimizer([1, 2, 3])
+    >>> optimizer = init.optimizer([1, 2, 3], 0.01)
     >>> isinstance(optimizer, SGD)
     True
-    >>> optimizer.params, optimizer.lr
-    ([1, 2, 3], 0.01)
+    >>> optimizer.params, optimizer.lr, optimizer.momentum
+    ([1, 2, 3], 0.01, 0.9)
 
 .. note::
 
@@ -997,11 +998,11 @@ Then a parser and behavior could be:
     >>> parser.add_class_arguments(Model, 'model')
     >>> cfg = parser.get_defaults()
     >>> cfg.model.optimizer
-    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.05))
+    Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.05, momentum=0.0))
     >>> init = parser.instantiate_classes(cfg)
     >>> optimizer = init.model.optimizer([1, 2, 3])
-    >>> optimizer.params, optimizer.lr
-    ([1, 2, 3], 0.05)
+    >>> optimizer.params, optimizer.lr, optimizer.momentum
+    ([1, 2, 3], 0.05, 0.0)
 
 See :ref:`ast-resolver` for limitations of lambda defaults.
 

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -972,11 +972,12 @@ A possible parser and callable behavior would be:
     >>> optimizer.params, optimizer.lr
     ([1, 2, 3], 0.01)
 
-Multiple dependency injection is also supported and can be specified the same
-way with ``Callable`` type hinting. For example, for two ``Iterable``
-dependencies, you can use the following syntax:
-``Callable[[Iterable, Iterable], Type]``. Please be aware that the injected
-dependencies passed as positional arguments (that is, passed as ``*args``).
+Multiple parameters available after injection are also supported and can be
+specified the same way with a ``Callable`` type hint. For example, for two
+``Iterable`` parameters, you can use the following syntax:
+``Callable[[Iterable, Iterable], Type]``. Please be aware that the parameters
+are passed as positional arguments, this means that the injected function would
+be called like ``function(value1, value2)``.
 
 .. note::
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -887,7 +887,7 @@ def subclass_spec_as_namespace(val, prev_val=None):
 def get_callable_return_type(typehint):
     return_type = None
     if len(getattr(typehint, "__args__", None) or []) > 1:
-        return_type = typehint.__args__[1]
+        return_type = typehint.__args__[-1]
     return return_type
 
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -640,7 +640,7 @@ def test_callable_args_function_path(parser):
 
 
 class Optimizer:
-    def __init__(self, params: List[float], lr: float = 1e-3, momentum: float = 0.):
+    def __init__(self, params: List[float], lr: float = 1e-3, momentum: float = 0.0):
         self.params = params
         self.lr = lr
         self.momentum = momentum
@@ -666,7 +666,7 @@ def test_callable_args_return_type_class(parser, subtests):
         assert isinstance(optimizer, SGD)
         assert [0.1, 2, 3] == optimizer.params
         assert 1e-3 == optimizer.lr
-        assert 0. == optimizer.momentum
+        assert 0.0 == optimizer.momentum
 
     with subtests.test("parse dict"):
         value = {
@@ -677,7 +677,7 @@ def test_callable_args_return_type_class(parser, subtests):
         }
         cfg = parser.parse_args([f"--optimizer={value}"])
         assert f"{__name__}.Adam" == cfg.optimizer.class_path
-        assert Namespace(lr=0.01, momentum=0.) == cfg.optimizer.init_args
+        assert Namespace(lr=0.01, momentum=0.0) == cfg.optimizer.init_args
         init = parser.instantiate_classes(cfg)
         optimizer = init.optimizer([4.5, 6.7])
         assert isinstance(optimizer, Adam)
@@ -706,14 +706,12 @@ def test_callable_multiple_args_return_type_class(parser, subtests):
         assert isinstance(optimizer, SGD)
         assert [0.1, 2, 3] == optimizer.params
         assert 1e-3 == optimizer.lr
-        assert 0. == optimizer.momentum
+        assert 0.0 == optimizer.momentum
 
     with subtests.test("parse dict"):
         value = {
             "class_path": "Adam",
-            "init_args": {
-                "momentum": 0.9
-            },
+            "init_args": {"momentum": 0.9},
         }
         cfg = parser.parse_args([f"--optimizer={value}"])
         assert f"{__name__}.Adam" == cfg.optimizer.class_path


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Fixes #372.

<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
