### PR TITLE
Subclass types no longer allow class instance to be set as default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,12 @@ Fixed
 - Failures with subcommands and default_config_files when keys are repeated
   (`#160 <https://github.com/omni-us/jsonargparse/issues/160>`__).
 
+Changed
+^^^^^^^
+- Subclass types no longer allow class instance to be set as default
+  (`lightning#18731
+  <https://github.com/Lightning-AI/lightning/issues/18731>`__).
+
 
 v4.25.0 (2023-09-25)
 --------------------

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -884,10 +884,9 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
                         raise KeyError(f'No action for destination key "{dest}" to set its default.')
                     elif isinstance(action, ActionConfigFile):
                         ActionConfigFile.set_default_error()
-                    action.default = default
                     if isinstance(action, ActionTypeHint):
-                        action.normalize_default()
-                    self._defaults[dest] = action.default
+                        default = action.normalize_default(default)
+                    self._defaults[dest] = action.default = default
         if kwargs:
             self.set_defaults(kwargs)
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -373,7 +373,8 @@ class SignatureArguments(LoggerProperty):
             }
             if is_dataclass_like_typehint:
                 kwargs.update(sub_add_kwargs)
-            action = group.add_argument(*args, **kwargs)
+            with ActionTypeHint.allow_default_instance_context():
+                action = group.add_argument(*args, **kwargs)
             action.sub_add_kwargs = sub_add_kwargs
             if is_subclass_typehint and len(subclass_skip) > 0:
                 action.sub_add_kwargs["skip"] = subclass_skip

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1462,6 +1462,12 @@ def test_subclass_required_parameters_missing(parser):
     ctx.match(" is required ")
 
 
+def test_subclass_get_defaults_lazy_instance(parser):
+    parser.add_argument("--op", type=RequiredParamsMissing, default=lazy_instance(RequiredParamsMissing, p1=1, p2="x"))
+    defaults = parser.get_defaults()
+    assert defaults.op.init_args == Namespace(p1=1, p2="x")
+
+
 @pytest.mark.parametrize("option", ["--op", "--op.help"])
 def test_subclass_class_name_ambiguous(parser, option):
     parser.add_argument("--op", type=Union[Calendar, GzipFile, None])


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning/issues/18731

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
