### PR TITLE
JSONARGPARSE_DEBUG follow environment variables standard of non-empty values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changed
 - Subclass types no longer allow class instance to be set as default
   (`lightning#18731
   <https://github.com/Lightning-AI/lightning/issues/18731>`__).
+- ``JSONARGPARSE_DEBUG`` must now have a non-empty value to enable debug mode.
 
 
 v4.25.0 (2023-09-25)

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -1818,11 +1818,11 @@ arguments.
 .. note::
 
     The parameter resolvers log messages of failures and unsupported cases. To
-    view these logs, set the environment variable ``JSONARGPARSE_DEBUG`` to any
-    value. The supported cases are limited and it is highly encouraged that
-    people create issues requesting the support for new ones. However, note that
-    when a case is highly convoluted it could be a symptom that the respective
-    code is in need of refactoring.
+    view these logs, set the environment variable ``JSONARGPARSE_DEBUG`` to a
+    non-empty truthy value. The supported cases are limited and it is highly
+    encouraged that people create issues requesting the support for new ones.
+    However, note that when a case is highly convoluted it could be a symptom
+    that the respective code is in need of refactoring.
 
 .. _stubs-resolver:
 
@@ -2563,7 +2563,7 @@ during development since there is not enough information to track down the root
 of the problem. Without the need to change the source code, this default
 behavior can be changed such that in case of failure, a ParseError exception is
 raised and the full stack trace is printed. This is done by setting the
-``JSONARGPARSE_DEBUG`` environment variable to any value.
+``JSONARGPARSE_DEBUG`` environment variable to a non-empty truthy value.
 
 The parsers from jsonargparse log some basic events, though by default this is
 disabled. To enable, the ``logger`` argument should be set when creating an

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -84,6 +84,7 @@ from ._util import (
     Path,
     argument_error,
     change_to_path_dir,
+    debug_mode_active,
     get_private_kwargs,
     identity,
     return_parser_if_captured,
@@ -995,12 +996,11 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
             self._error_handler(self, message)
         if not self.exit_on_error:
             raise argument_error(message) from ex
-        elif "JSONARGPARSE_DEBUG" in os.environ:
+        elif debug_mode_active():
             self._logger.debug("Debug enabled, thus raising exception instead of exit.")
             raise argument_error(message) from ex
-        self.print_usage(sys.stderr)
-        args = {"prog": self.prog, "message": message}
-        sys.stderr.write("%(prog)s: error: %(message)s\n" % args)
+        self.print_usage()
+        sys.stderr.write(f"error: {message}\n")
         self.exit(2)
 
     def check_config(

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -765,10 +765,14 @@ class LoggerProperty:
 
             deprecation_warning((LoggerProperty.logger, None), logger_property_none_message)
             logger = False
-        if not logger and "JSONARGPARSE_DEBUG" in os.environ:
+        if not logger and debug_mode_active():
             logger = {"level": "DEBUG"}
         self._logger = parse_logger(logger, type(self).__name__)
 
 
-if "JSONARGPARSE_DEBUG" in os.environ:
+def debug_mode_active() -> bool:
+    return os.getenv("JSONARGPARSE_DEBUG", "").lower() not in {"", "false", "no", "0"}
+
+
+if debug_mode_active():
     os.environ["LOGGER_LEVEL"] = "DEBUG"  # pragma: no cover

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -922,7 +922,7 @@ def test_version_print():
     assert out == "app 1.2.3\n"
 
 
-@patch.dict(os.environ, {"JSONARGPARSE_DEBUG": ""})
+@patch.dict(os.environ, {"JSONARGPARSE_DEBUG": "true"})
 def test_debug_environment_variable(logger):
     parser = ArgumentParser(logger=logger)
     parser.add_argument("--int", type=int)


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
