### PR TITLE
Fix failures when choices is a dict_keys object and value non-hashable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.26.1 (2023-10-??)
+--------------------
+
+Fixed
+^^^^^
+- Failures when choices is a ``dict_keys`` object and value non-hashable.
+
+
 v4.26.0 (2023-10-19)
 --------------------
 

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -131,6 +131,8 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
                     container=super(),
                     logger=self._logger,
                 )
+        if "choices" in kwargs and not isinstance(kwargs["choices"], (list, tuple)):
+            kwargs["choices"] = tuple(kwargs["choices"])
         action = super().add_argument(*args, **kwargs)
         action.logger = self._logger  # type: ignore
         ActionConfigFile._add_print_config_argument(self, action)

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -156,6 +156,15 @@ def test_parse_args_choices_config(parser):
     pytest.raises(ArgumentError, lambda: parser.parse_args(["--cfg=ch2: v0"]))
 
 
+def test_parse_args_non_hashable_choice(parser):
+    choices = {"A": 1, "B": 2}
+    parser.add_argument("--cfg", action=ActionConfigFile)
+    parser.add_argument("--ch1", choices=choices.keys())
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(["--cfg=ch1: [1,2]"])
+    ctx.match("not among choices")
+
+
 def test_parse_object_simple(parser):
     parser.add_argument("--op", type=int)
     assert parser.parse_object({"op": 1}) == Namespace(op=1)


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
