### PR TITLE
Fix AST resolver not using the correct component globals in some cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ v4.26.1 (2023-10-??)
 Fixed
 ^^^^^
 - Failures when choices is a ``dict_keys`` object and value non-hashable.
+- AST resolver not using the correct component globals in some cases.
 
 
 v4.26.0 (2023-10-19)

--- a/jsonargparse_tests/conftest.py
+++ b/jsonargparse_tests/conftest.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
+from functools import wraps
 from importlib.util import find_spec
 from io import StringIO
 from pathlib import Path
@@ -157,3 +158,16 @@ def get_parse_args_stderr(parser: ArgumentParser, args: List[str]) -> str:
         with redirect_stderr(err), pytest.raises(SystemExit):
             parser.parse_args(args)
     return err.getvalue()
+
+
+class BaseClass:
+    def __init__(self):
+        pass
+
+
+def wrap_fn(fn):
+    @wraps(fn)
+    def wrapped_fn(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapped_fn


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
