### PR TITLE
Fix choices working incorrectly when nargs is +, * or number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 ^^^^^
 - Failure to parse subclass added via add_argument and required arg as link
   target.
+- ``choices`` working incorrectly when ``nargs`` is ``+``, ``*`` or number.
 
 
 v4.26.1 (2023-10-23)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -1354,8 +1354,12 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
                         value[k] = action.type(v)
             except (TypeError, ValueError) as ex:
                 raise TypeError(f'Parser key "{key}": {ex}') from ex
-        if not is_subcommand and action.choices and value not in action.choices:
-            raise TypeError(f'Parser key "{key}": {value!r} not among choices {action.choices}')
+        if not is_subcommand and action.choices:
+            vals = value if _is_action_value_list(action) else [value]
+            assert isinstance(vals, list)
+            for val in vals:
+                if val not in action.choices:
+                    raise TypeError(f'Parser key "{key}": {val!r} not among choices {action.choices}')
         return value
 
     ## Properties ##

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -165,6 +165,14 @@ def test_parse_args_non_hashable_choice(parser):
     ctx.match("not among choices")
 
 
+def test_parse_args_choices_nargs_plus(parser):
+    parser.add_argument("--ch", nargs="+", choices=["A", "B"])
+    assert ["A", "B"] == parser.parse_args(["--ch", "A", "B"]).ch
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(["--ch", "B", "X"])
+    ctx.match("invalid choice")
+
+
 def test_parse_object_simple(parser):
     parser.add_argument("--op", type=int)
     assert parser.parse_object({"op": 1}) == Namespace(op=1)


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
