### PR TITLE
Fix confusing error message when adding signature parameters that conflict with existing arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.27.1 (2023-11-??)
+--------------------
+
+Fixed
+^^^^^
+- Confusing error message when adding signature parameters that conflict with
+  existing arguments.
+
+
 v4.27.0 (2023-11-02)
 --------------------
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -242,6 +242,14 @@ class SignatureArguments(LoggerProperty):
                 f"Skipping parameters {names} because {skip_positionals[0]} positionals requested to be skipped."
             )
 
+        prefix = "--" + (nested_key + "." if nested_key else "")
+        for param in params:
+            if prefix + param.name in self._option_string_actions:  # type: ignore
+                raise ValueError(
+                    f"Unable to add parameter '{param.name}' from {function_or_class} because "
+                    f"argument '{prefix + param.name}' already exists."
+                )
+
         ## Create group if requested ##
         doc_group = get_doc_short_description(function_or_class, method_name, logger=self.logger)
         component = getattr(function_or_class, method_name) if method_name else function_or_class

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -613,3 +613,14 @@ def test_add_function_group_config_within_config(parser, tmp_cwd):
     cfg = parser.parse_args([f"--cfg={cfg_path}"])
     assert str(cfg.func.__path__) == str(subcfg_path)
     assert strip_meta(cfg.func) == Namespace(a1="one", a2=2.0, a3=True)
+
+
+def func_param_conflict(p1: int, cfg: dict):
+    pass
+
+
+def test_add_function_param_conflict(parser):
+    parser.add_argument("--cfg", action=ActionConfigFile)
+    with pytest.raises(ValueError) as ctx:
+        parser.add_function_arguments(func_param_conflict)
+    ctx.match("Unable to add parameter 'cfg' from")


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
