### PR TITLE
Fix signature parameter default value that doesn't match its type considered invalid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ v4.27.2 (2024-01-??)
 Fixed
 ^^^^^
 - reconplogger's logger level being unexpectedly overwritten.
+- Signature parameter default value that doesn't match its type considered
+  invalid (`lightning#19289 comment
+  <https://github.com/Lightning-AI/pytorch-lightning/pull/19289#issuecomment-1894063743>`__)
 
 
 v4.27.1 (2023-11-23)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -495,7 +495,10 @@ class ActionTypeHint(Action):
                 except ValueError as ex:
                     assert ex  # needed due to ruff bug that removes " as ex"
                     try:
-                        if isinstance(orig_val, str):
+                        if orig_val is not None and orig_val == self.default:
+                            val = orig_val
+                            ex = None
+                        elif isinstance(orig_val, str):
                             with change_to_path_dir(config_path):
                                 val = adapt_typehints(orig_val, self._typehint, **kwargs)
                             ex = None

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -624,3 +624,13 @@ def test_add_function_param_conflict(parser):
     with pytest.raises(ValueError) as ctx:
         parser.add_function_arguments(func_param_conflict)
     ctx.match("Unable to add parameter 'cfg' from")
+
+
+def func_unmatched_default_type(p1: str, p2: bool = "deprecated"):  # type: ignore[assignment]
+    return p1
+
+
+def test_add_function_unmatched_default_type(parser):
+    parser.add_function_arguments(func_unmatched_default_type)
+    cfg = parser.parse_args(["--p1=x"])
+    assert cfg.p1 == "x"


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/pytorch-lightning/pull/19289#issuecomment-1894063743

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
