### PR TITLE
Fix signature parameter default that doesn't match its type failing on instantiation and serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Fixed
 ^^^^^
 - Argument links not working for target ``init_args`` in an optional list (`#433
   <https://github.com/omni-us/jsonargparse/issues/433>`__).
+- Signature parameter default that doesn't match its type failing on
+  instantiation and serialization (`lightning#19289 comment
+  <https://github.com/Lightning-AI/pytorch-lightning/pull/19289#issuecomment-1902618722>`__)
 
 
 v4.27.2 (2024-01-18)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/pytorch-lightning/pull/19289#issuecomment-1902618722

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
