### PR TITLE
Fix confusing error message when CLI is used with a class that defines a subcommand method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Fixed
 ^^^^^
 - ``argcomplete`` not working when type and choices given (`#442
   <https://github.com/omni-us/jsonargparse/issues/442>`__).
+- Confusing error message when ``CLI`` is used with a class that defines a
+  ``subcommand`` method (`#430 comment
+  <https://github.com/omni-us/jsonargparse/issues/430#issuecomment-1903974112>`__).
 
 
 v4.27.3 (2024-01-26)

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -604,6 +604,8 @@ class _ActionSubCommands(_SubParsersAction):
         """
         if parser._subparsers is not None:
             raise ValueError("Multiple levels of subcommands must be added in level order.")
+        if self.dest == name:
+            raise ValueError(f"A subcommand name can't be the same as the subcommands dest: '{name}'.")
 
         parser.prog = f"{self._prog_prefix} [options] {name}"
         parser.env_prefix = f"{self.env_prefix}{name}_"

--- a/jsonargparse_tests/test_cli.py
+++ b/jsonargparse_tests/test_cli.py
@@ -34,6 +34,17 @@ def test_unexpected_components(components):
         CLI(components)
 
 
+class ConflictingSubcommandKey:
+    def subcommand(self, x: int = 0):
+        return x
+
+
+def test_conflicting_subcommand_key():
+    with pytest.raises(ValueError) as ctx:
+        CLI(ConflictingSubcommandKey, args=["subcommand", "--x=1"])
+    assert ctx.match("subcommand name can't be the same")
+
+
 # single function tests
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
