### PR TITLE
CLI should not add --config parameter when a class method has a config parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Fixed
 - Confusing error message when ``CLI`` is used with a class that defines a
   ``subcommand`` method (`#430 comment
   <https://github.com/omni-us/jsonargparse/issues/430#issuecomment-1903974112>`__).
+- ``CLI`` crashes when a method has a ``config`` parameter. Due to redundancy,
+  ``--config`` argument should not be added.
 
 
 v4.27.3 (2024-01-26)

--- a/jsonargparse_tests/test_cli.py
+++ b/jsonargparse_tests/test_cli.py
@@ -192,6 +192,16 @@ def test_single_class_print_config_before_subcommand():
     assert cfg == {"i1": "0", "method1": {"m1": 2}}
 
 
+class MethodWithConfigParam:
+    def cmd(self, p1: int = 1, config: dict = {}):
+        print(f"p1: {p1}, config: {config}")
+
+
+def test_method_with_config_parameter():
+    out = get_cli_stdout(MethodWithConfigParam, args=["cmd"])
+    assert "p1: 1, config: {}" == out.strip()
+
+
 # function and class tests
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
