### PR TITLE
Fix confusing error message when creating a link with a target that is already a target of another link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Fixed
 - Importable class instances fail to parse and serialize (`#446
   <https://github.com/omni-us/jsonargparse/issues/446>`__).
 - Failure when trying to pickle instances created with ``lazy_instance``.
+- Confusing error message when creating a link with a target that is already a
+  target of another link.
 
 
 v4.27.4 (2024-02-01)

--- a/jsonargparse/_link_arguments.py
+++ b/jsonargparse/_link_arguments.py
@@ -241,6 +241,8 @@ class ActionLink(Action):
             # Check source
             link_actions = self.parser._links_group._group_actions
             existing_targets = {a.target[0] for a in link_actions}
+            if target in existing_targets:
+                raise ValueError(f'Target "{target}" is already a target of another link.')
             for src in [source] if isinstance(source, str) else source:
                 if src in existing_targets:
                     raise ValueError(f'Source "{src}" not allowed since it is the target of another link.')

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -819,8 +819,9 @@ def test_on_instantiate_within_deeper_subclass(parser, caplog):
 def test_link_failure_invalid_apply_on(parser):
     parser.add_argument("--a")
     parser.add_argument("--b")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ctx:
         parser.link_arguments("a", "b", apply_on="bad")
+    ctx.match("apply_on must be 'parse' or 'instantiate'")
 
 
 def test_on_parse_link_failure_previous_target_as_source(parser):
@@ -845,14 +846,15 @@ def test_on_parse_link_failure_previous_source_as_target(parser):
 
 def test_on_parse_link_failure_already_linked():
     parser = parser_classes_links_on_parse()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ctx:
         parser.link_arguments("a.v2", "b.v1")
+    ctx.match('Target "b.v1" is already a target of another link')
 
 
 def test_on_parse_link_failure_non_existing_source():
     parser = parser_classes_links_on_parse()
     with pytest.raises(ValueError) as ctx:
-        parser.link_arguments("x", "b.v2")
+        parser.link_arguments("x", "b.v3")
     ctx.match('No action for key "x"')
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
