### PR TITLE
Fix failure when getting parameters from a class created with class_from_function from a classmethod without parameter types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.27.6 (2024-02-??)
+--------------------
+
+Fixed
+^^^^^
+- Failure when getting parameters from a class created with
+  ``class_from_function`` from a ``classmethod`` without parameter types (`#456
+  <https://github.com/omni-us/jsonargparse/issues/456>`__).
+
+
 v4.27.5 (2024-02-12)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,8 +18,8 @@ v4.27.6 (2024-02-??)
 Fixed
 ^^^^^
 - Failure when getting parameters from a class created with
-  ``class_from_function`` from a ``classmethod`` without parameter types (`#456
-  <https://github.com/omni-us/jsonargparse/issues/456>`__).
+  ``class_from_function`` from a ``classmethod`` without parameter types (`#454
+  <https://github.com/omni-us/jsonargparse/issues/454>`__).
 
 
 v4.27.5 (2024-02-12)

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -10,6 +10,7 @@ from contextvars import ContextVar
 from copy import deepcopy
 from functools import partial
 from importlib import import_module
+from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from ._common import LoggerProperty, get_generic_origin, is_dataclass_like, is_generic_class, is_subclass, parse_logger
@@ -444,7 +445,11 @@ def get_component_and_parent(
 ):
     if is_subclass(function_or_class, ClassFromFunctionBase) and method_or_property in {None, "__init__"}:
         function_or_class = function_or_class.wrapped_function  # type: ignore[union-attr]
-        method_or_property = None
+        if isinstance(function_or_class, MethodType):
+            method_or_property = function_or_class.__name__
+            function_or_class = function_or_class.__self__  # type: ignore[assignment]
+        else:
+            method_or_property = None
     elif inspect.isclass(get_generic_origin(function_or_class)) and method_or_property is None:
         method_or_property = "__init__"
     elif method_or_property and not isinstance(method_or_property, str):

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -661,6 +661,35 @@ def test_get_params_class_from_function():
         assert_params(params, ["pk1", "k2"])
 
 
+class ClassMethod:
+    def __init__(self, pi: int):
+        self.pi = pi
+
+    @classmethod
+    def from_str(cls, ps: str):
+        return cls(1)
+
+    @classmethod
+    def from_untyped(cls, pu):
+        return cls(2)
+
+
+ClassMethodFromStr = class_from_function(ClassMethod.from_str, ClassMethod, name="ClassMethodFromStr")
+ClassMethodFromUntyped = class_from_function(ClassMethod.from_untyped, ClassMethod, name="ClassMethodFromUntyped")
+
+
+def test_get_params_class_from_function_classmethod_typed():
+    params = get_params(ClassMethodFromStr)
+    assert [p.name for p in params] == ["ps"]
+    assert params[0].annotation is str
+
+
+def test_get_params_class_from_function_classmethod_untyped():
+    params = get_params(ClassMethodFromUntyped)
+    assert [p.name for p in params] == ["pu"]
+    assert params[0].annotation is inspect._empty
+
+
 def test_get_params_class_instance_defaults(subtests):
     params = get_params(ClassInstanceDefaults)
     assert_params(


### PR DESCRIPTION
## What does this PR do?

Fixes #454

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
