### PR TITLE
Fix dataclass single parameter change incorrectly resetting previous values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/issues/465>`__).
 - Optional callable that returns a class instance with a lambda default,
   produces an invalid string default.
+- dataclass single parameter change incorrectly resetting previous values (`#464
+  <https://github.com/omni-us/jsonargparse/issues/464>`__).
 
 
 v4.27.5 (2024-02-12)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -863,7 +863,8 @@ def adapt_typehints(
         elif isinstance(val, (dict, Namespace)):
             val = parser.parse_object(val, defaults=sub_defaults.get() or list_item)
         elif isinstance(val, NestedArg):
-            val = parser.parse_args([f"--{val.key}={val.val}"])
+            prev_val = prev_val if isinstance(prev_val, Namespace) else None
+            val = parser.parse_args([f"--{val.key}={val.val}"], namespace=prev_val)
         else:
             raise_unexpected_value(f"Type {typehint} expects a dict or Namespace", val)
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from jsonargparse import (
+    ActionConfigFile,
     ArgumentError,
     ArgumentParser,
     Namespace,
@@ -357,6 +358,20 @@ def test_optional_dataclass_type_null_value():
     cfg = parser_optional_data.parse_args(["--data=null"])
     assert cfg == Namespace(data=None)
     assert cfg == parser_optional_data.instantiate_classes(cfg)
+
+
+@dataclasses.dataclass
+class SingleParamChange:
+    p1: int = 0
+    p2: int = 0
+
+
+def test_optional_dataclass_single_param_change(parser):
+    parser.add_argument("--config", action=ActionConfigFile)
+    parser.add_argument("--data", type=Optional[SingleParamChange])
+    config = {"data": {"p1": 1}}
+    cfg = parser.parse_args([f"--config={config}", "--data.p2=2"])
+    assert cfg.data == Namespace(p1=1, p2=2)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## What does this PR do?

Fixes #464.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
