### PR TITLE
Feature path std io

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+v4.28.0 (2024-03-??)
+--------------------
+
+Added
+^^^^^
+- Support for "-" as value for Path class initialization so that user
+  can ask to use standard input/output instead of file.
 
 v4.27.6 (2024-02-??)
 --------------------

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -457,6 +457,11 @@ class Path(PathDeprecations):
     The creatable flag "c" can be given one or two times. If give once, the
     parent directory must exist and be writeable. If given twice, the parent
     directory does not have to exist, but should be allowed to create.
+
+    An instance of Path class can also refer to the standard input or output.
+    To do that, path must be set with the value "-"; it is a common practice.
+    Then, getting the content or opening it will automatically be done on
+    standard input or output.
     """
 
     _url_data: Optional[UrlData]

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -697,5 +697,7 @@ def test_std_input_path():
 def test_std_output_path():
     path = Path("-", mode="")
     assert path == "-"
-    path.open("w")
+    with patch("sys.stdout", StringIO("")):
+        with path.open("w") as std_output:
+            std_output.write("test\n")
     assert path.std_io

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -7,6 +7,7 @@ import stat
 import zipfile
 from calendar import Calendar
 from importlib import import_module
+from io import StringIO
 from random import Random
 from unittest.mock import patch
 
@@ -677,3 +678,16 @@ def test_capture_parser():
     with pytest.raises(CaptureParserException) as ctx:
         capture_parser(lambda: None)
     ctx.match("No parse_args call to capture the parser")
+
+
+def test_std_input_path():
+    input_text_to_test = "a text here\n"
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="")
+        assert path == "-"
+        assert input_text_to_test == path.get_content("r")
+
+
+def test_std_output_path():
+    path = Path("-", mode="")
+    assert path == "-"

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -686,8 +686,16 @@ def test_std_input_path():
         path = Path("-", mode="")
         assert path == "-"
         assert input_text_to_test == path.get_content("r")
+        assert path.std_io
+
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="")
+        with path.open("r") as std_input:
+            assert input_text_to_test == "".join([line for line in std_input])
 
 
 def test_std_output_path():
     path = Path("-", mode="")
     assert path == "-"
+    path.open("w")
+    assert path.std_io


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Add support for "-" as value for Path class initialization so that user
  can ask to use standard input/output instead of file.

## Before submitting

- [ X ] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ X ] Did you update **the documentation**? (readme and public docstrings)
- [ X ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [ X ] Did you verify that new and existing **tests pass locally**?
- [ X ] Did you make sure that all changes preserve **backward compatibility**?
- [ X ] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
