### PR TITLE
Feature path std io

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+v4.28.0 (2024-03-??)
+--------------------
+
+Added
+^^^^^
+- Support for "-" as value for Path class initialization so that user
+  can ask to use standard input/output instead of file.
 
 v4.27.6 (2024-02-??)
 --------------------

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -484,6 +484,7 @@ class Path(PathDeprecations):
         is_url = False
         is_fsspec = False
         if isinstance(path, Path):
+            self.std_io = path._std_io
             is_url = path.is_url
             is_fsspec = path.is_fsspec
             url_data = path._url_data

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -457,6 +457,11 @@ class Path(PathDeprecations):
     The creatable flag "c" can be given one or two times. If give once, the
     parent directory must exist and be writeable. If given twice, the parent
     directory does not have to exist, but should be allowed to create.
+
+    An instance of Path class can also refer to the standard input or output.
+    To do that, path must be set with the value "-"; it is a common practice.
+    Then, getting the content or opening it will automatically be done on
+    standard input or output.
     """
 
     _url_data: Optional[UrlData]

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -572,23 +572,21 @@ class Path(PathDeprecations):
                 if "f" in mode and not (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
                     raise TypeError(f"Path is not a file: {abs_path!r}")
 
-            if self.std_io:
-                pass
-            elif "r" in mode and not os.access(abs_path, os.R_OK):
+            if "r" in mode and not os.access(abs_path, os.R_OK):
                 raise TypeError(f"{ptype} is not readable: {abs_path!r}")
-            elif "w" in mode and not os.access(abs_path, os.W_OK):
+            if "w" in mode and not os.access(abs_path, os.W_OK):
                 raise TypeError(f"{ptype} is not writeable: {abs_path!r}")
-            elif "x" in mode and not os.access(abs_path, os.X_OK):
+            if "x" in mode and not os.access(abs_path, os.X_OK):
                 raise TypeError(f"{ptype} is not executable: {abs_path!r}")
-            elif "D" in mode and os.path.isdir(abs_path):
+            if "D" in mode and os.path.isdir(abs_path):
                 raise TypeError(f"Path is a directory: {abs_path!r}")
-            elif "F" in mode and (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
+            if "F" in mode and (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
                 raise TypeError(f"Path is a file: {abs_path!r}")
-            elif "R" in mode and os.access(abs_path, os.R_OK):
+            if "R" in mode and os.access(abs_path, os.R_OK):
                 raise TypeError(f"{ptype} is readable: {abs_path!r}")
-            elif "W" in mode and os.access(abs_path, os.W_OK):
+            if "W" in mode and os.access(abs_path, os.W_OK):
                 raise TypeError(f"{ptype} is writeable: {abs_path!r}")
-            elif "X" in mode and os.access(abs_path, os.X_OK):
+            if "X" in mode and os.access(abs_path, os.X_OK):
                 raise TypeError(f"{ptype} is executable: {abs_path!r}")
 
         self._relative = path

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -156,14 +156,6 @@ class CachedStdin(StringIO):
     """Used to allow reading sys.stdin multiple times."""
 
 
-def read_stdin() -> str:
-    if not isinstance(sys.stdin, CachedStdin):
-        sys.stdin = CachedStdin(sys.stdin.read())
-    value = sys.stdin.read()
-    sys.stdin.seek(0)
-    return value
-
-
 def import_object(name: str):
     """Returns an object in a module given its dot import path."""
     if not isinstance(name, str) or "." not in name:

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -133,7 +133,7 @@ def parse_value_or_config(
         nested_arg = value
         value = nested_arg.val
     cfg_path = None
-    if enable_path and type(value) is str:
+    if enable_path and type(value) is str and value != "-":
         try:
             cfg_path = Path(value, mode=get_config_read_mode())
         except TypeError:
@@ -547,7 +547,7 @@ class Path(PathDeprecations):
                     raise TypeError(f"Path does not exist: {abs_path!r}") from ex
                 except PermissionError as ex:
                     raise TypeError(f"Path exists but no permission to access: {abs_path!r}") from ex
-        elif not self._skip_check:
+        elif not self._skip_check and not self.std_io:
             ptype = "Directory" if "d" in mode else "File"
             if "c" in mode:
                 pdir = os.path.realpath(os.path.join(abs_path, ".."))
@@ -571,21 +571,24 @@ class Path(PathDeprecations):
                     raise TypeError(f"Path is not a directory: {abs_path!r}")
                 if "f" in mode and not (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
                     raise TypeError(f"Path is not a file: {abs_path!r}")
-            if "r" in mode and not os.access(abs_path, os.R_OK):
+
+            if self.std_io:
+                pass
+            elif "r" in mode and not os.access(abs_path, os.R_OK):
                 raise TypeError(f"{ptype} is not readable: {abs_path!r}")
-            if "w" in mode and not os.access(abs_path, os.W_OK):
+            elif "w" in mode and not os.access(abs_path, os.W_OK):
                 raise TypeError(f"{ptype} is not writeable: {abs_path!r}")
-            if "x" in mode and not os.access(abs_path, os.X_OK):
+            elif "x" in mode and not os.access(abs_path, os.X_OK):
                 raise TypeError(f"{ptype} is not executable: {abs_path!r}")
-            if "D" in mode and os.path.isdir(abs_path):
+            elif "D" in mode and os.path.isdir(abs_path):
                 raise TypeError(f"Path is a directory: {abs_path!r}")
-            if "F" in mode and (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
+            elif "F" in mode and (os.path.isfile(abs_path) or stat.S_ISFIFO(os.stat(abs_path).st_mode)):
                 raise TypeError(f"Path is a file: {abs_path!r}")
-            if "R" in mode and os.access(abs_path, os.R_OK):
+            elif "R" in mode and os.access(abs_path, os.R_OK):
                 raise TypeError(f"{ptype} is readable: {abs_path!r}")
-            if "W" in mode and os.access(abs_path, os.W_OK):
+            elif "W" in mode and os.access(abs_path, os.W_OK):
                 raise TypeError(f"{ptype} is writeable: {abs_path!r}")
-            if "X" in mode and os.access(abs_path, os.X_OK):
+            elif "X" in mode and os.access(abs_path, os.X_OK):
                 raise TypeError(f"{ptype} is executable: {abs_path!r}")
 
         self._relative = path

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -539,7 +539,7 @@ class Path(PathDeprecations):
                     raise TypeError(f"Path does not exist: {abs_path!r}") from ex
                 except PermissionError as ex:
                     raise TypeError(f"Path exists but no permission to access: {abs_path!r}") from ex
-        elif not self._skip_check and not self.std_io:
+        elif not self._skip_check and not self._std_io:
             ptype = "Directory" if "d" in mode else "File"
             if "c" in mode:
                 pdir = os.path.realpath(os.path.join(abs_path, ".."))
@@ -588,11 +588,6 @@ class Path(PathDeprecations):
         self._is_url = is_url
         self._is_fsspec = is_fsspec
         self._url_data = url_data
-
-    @property
-    def std_io(self) -> bool:
-        """Flag specifying if the Path is a standard input or output"""
-        return self._std_io
 
     @property
     def relative(self) -> str:
@@ -647,7 +642,7 @@ class Path(PathDeprecations):
 
     def get_content(self, mode: str = "r") -> str:
         """Returns the contents of the file or the remote path."""
-        if self.std_io:
+        if self._std_io:
             return sys.stdin.read()
         elif self._is_url:
             assert mode == "r"
@@ -667,7 +662,7 @@ class Path(PathDeprecations):
     @contextmanager
     def open(self, mode: str = "r") -> Iterator[IO]:
         """Return an opened file object for the path."""
-        if self.std_io:
+        if self._std_io:
             if "r" in mode:
                 yield sys.stdin
             elif "w" in mode:

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -697,5 +697,7 @@ def test_std_input_path():
 def test_std_output_path():
     path = Path("-", mode="")
     assert path == "-"
-    path.open("w")
+    with patch("sys.stdout", StringIO("")):
+        with path.open("w") as std_output:
+            std_output.write("test\n")
     assert path.std_io

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -693,9 +693,33 @@ def test_std_input_path():
         with path.open("r") as std_input:
             assert input_text_to_test == "".join([line for line in std_input])
 
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="r")
+        with path.open("r") as std_input:
+            assert input_text_to_test == "".join([line for line in std_input])
+
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="fr")
+        with path.open("r") as std_input:
+            assert input_text_to_test == "".join([line for line in std_input])
+
 
 def test_std_output_path():
     path = Path("-", mode="")
+    assert path == "-"
+    with patch("sys.stdout", StringIO("")):
+        with path.open("w") as std_output:
+            std_output.write("test\n")
+    assert path.std_io
+
+    path = Path("-", mode="w")
+    assert path == "-"
+    with patch("sys.stdout", StringIO("")):
+        with path.open("w") as std_output:
+            std_output.write("test\n")
+    assert path.std_io
+
+    path = Path("-", mode="fw")
     assert path == "-"
     with patch("sys.stdout", StringIO("")):
         with path.open("w") as std_output:

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -7,6 +7,7 @@ import stat
 import zipfile
 from calendar import Calendar
 from importlib import import_module
+from io import StringIO
 from random import Random
 from unittest.mock import patch
 
@@ -677,3 +678,16 @@ def test_capture_parser():
     with pytest.raises(CaptureParserException) as ctx:
         capture_parser(lambda: None)
     ctx.match("No parse_args call to capture the parser")
+
+
+def test_std_input_path():
+    input_text_to_test = "a text here\n"
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="")
+        assert path == "-"
+        assert input_text_to_test == path.get_content("r")
+
+
+def test_std_output_path():
+    path = Path("-", mode="")
+    assert path == "-"

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -217,6 +217,30 @@ def test_path_tilde_home(paths):
         assert path() == os.path.join(paths.tmp_path, paths.file_rw)
 
 
+def test_std_input_path():
+    input_text_to_test = "a text here\n"
+
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="fr")
+        assert path == "-"
+        assert input_text_to_test == path.get_content("r")
+
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="fr")
+        with path.open("r") as std_input:
+            assert input_text_to_test == "".join([line for line in std_input])
+
+
+def test_std_output_path():
+    path = Path("-", mode="fw")
+    assert path == "-"
+    output = StringIO("")
+    with patch("sys.stdout", output):
+        with path.open("w") as std_output:
+            std_output.write("test\n")
+    assert output.getvalue() == "test\n"
+
+
 # url tests
 
 
@@ -678,50 +702,3 @@ def test_capture_parser():
     with pytest.raises(CaptureParserException) as ctx:
         capture_parser(lambda: None)
     ctx.match("No parse_args call to capture the parser")
-
-
-def test_std_input_path():
-    input_text_to_test = "a text here\n"
-    with patch("sys.stdin", StringIO(input_text_to_test)):
-        path = Path("-", mode="")
-        assert path == "-"
-        assert input_text_to_test == path.get_content("r")
-        assert path.std_io
-
-    with patch("sys.stdin", StringIO(input_text_to_test)):
-        path = Path("-", mode="")
-        with path.open("r") as std_input:
-            assert input_text_to_test == "".join([line for line in std_input])
-
-    with patch("sys.stdin", StringIO(input_text_to_test)):
-        path = Path("-", mode="r")
-        with path.open("r") as std_input:
-            assert input_text_to_test == "".join([line for line in std_input])
-
-    with patch("sys.stdin", StringIO(input_text_to_test)):
-        path = Path("-", mode="fr")
-        with path.open("r") as std_input:
-            assert input_text_to_test == "".join([line for line in std_input])
-
-
-def test_std_output_path():
-    path = Path("-", mode="")
-    assert path == "-"
-    with patch("sys.stdout", StringIO("")):
-        with path.open("w") as std_output:
-            std_output.write("test\n")
-    assert path.std_io
-
-    path = Path("-", mode="w")
-    assert path == "-"
-    with patch("sys.stdout", StringIO("")):
-        with path.open("w") as std_output:
-            std_output.write("test\n")
-    assert path.std_io
-
-    path = Path("-", mode="fw")
-    assert path == "-"
-    with patch("sys.stdout", StringIO("")):
-        with path.open("w") as std_output:
-            std_output.write("test\n")
-    assert path.std_io

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -686,8 +686,16 @@ def test_std_input_path():
         path = Path("-", mode="")
         assert path == "-"
         assert input_text_to_test == path.get_content("r")
+        assert path.std_io
+
+    with patch("sys.stdin", StringIO(input_text_to_test)):
+        path = Path("-", mode="")
+        with path.open("r") as std_input:
+            assert input_text_to_test == "".join([line for line in std_input])
 
 
 def test_std_output_path():
     path = Path("-", mode="")
     assert path == "-"
+    path.open("w")
+    assert path.std_io


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Add support for "-" as value for Path class initialization so that user
can ask to use standard input/output instead of file.

For instance, users who are used to type their input files with Path_fr will now be able to give "-" as input string so that get_content or open (of Path_fr class) will read the standard input stream without having nothing more to do. Same for output.

Note that some code has been added for typehiting so that it does not create conflict with another feature: giving "-" to specify that a list of files is given through the standard input.

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [ X ] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ X ] Did you update **the documentation**? (readme and public docstrings)
- [ X ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [ X ] Did you verify that new and existing **tests pass locally**?
- [ X ] Did you make sure that all changes preserve **backward compatibility**?
- [ X ] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
