### PR TITLE
Fix regression that prevented **kwargs parameter resolving when an Optional[Callable] type is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,18 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.27.7 (2024-03-??)
+--------------------
+
+Fixed
+^^^^^
+- Regression from `14456c2
+  <https://github.com/omni-us/jsonargparse/commit/14456c21ff7a11ba420f010d2b21bcfdb14977a2>`__
+  that prevented ``**kwargs`` parameter resolving when an ``Optional[Callable]``
+  type is used (`#473
+  <https://github.com/omni-us/jsonargparse/issues/473>`__).
+
+
 v4.27.6 (2024-03-15)
 --------------------
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -955,7 +955,11 @@ def get_callable_return_type(typehint):
 
 def get_subclass_types(typehint, callable_return=True):
     subclass_types = None
-    if callable_return and ActionTypeHint.is_callable_typehint(typehint, all_subtypes=False) and typehint.__args__:
+    if (
+        callable_return
+        and ActionTypeHint.is_callable_typehint(typehint, all_subtypes=False)
+        and getattr(typehint, "__args__", None)
+    ):
         typehint = get_optional_arg(typehint)
         typehint = typehint.__args__[-1]
     if ActionTypeHint.is_subclass_typehint(typehint, all_subtypes=False):

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -5,7 +5,7 @@ import inspect
 import xml.dom
 from calendar import Calendar
 from random import shuffle
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from unittest.mock import patch
 
 import pytest
@@ -541,6 +541,14 @@ def conditional_calls(**kwargs):
         cond_3(**kwargs)
 
 
+def function_optional_callable(p1: Optional[Callable] = None, **kw):
+    """
+    Args:
+        p1: help for p1
+    """
+    function_no_args_no_kwargs(**kw)
+
+
 def assert_params(params, expected, origins={}):
     assert expected == [p.name for p in params]
     docs = [f"help for {p.name}" for p in params] if docstring_parser_support else [None] * len(params)
@@ -862,6 +870,10 @@ def test_conditional_calls_kwargs():
     )
     with source_unavailable():
         assert get_params(conditional_calls) == []
+
+
+def test_get_params_optional_callable():
+    assert_params(get_params(function_optional_callable), ["p1", "pk1", "k2"])
 
 
 # unsupported cases


### PR DESCRIPTION
## What does this PR do?

Fixes #473.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
