### PR TITLE
Fixes for non-stdlib dataclass-like types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,20 @@ paths are considered internals and can change in minor and patch releases.
 v4.28.1 (2024-0?-??)
 --------------------
 
+Added
+^^^^^
+- `TypeAliasType` support added (`#480
+  <https://github.com/omni-us/jsonargparse/issues/480>`__).
+
 Fixed
 ^^^^^
--  Failure to process ``Annotated`` dataclass members, and inclusion of
-   non-init fields in `attrs` and Pydantic dataclass-like instantiation.
+- Attrs and Pydantic 2 dataclasses with non-init fields fail to instantiate
+  (`#480 <https://github.com/omni-us/jsonargparse/issues/480>`__).
+- Default values/factories for Pydantic 2 dataclasses with `Field` initializers
+  are not right (`#480 <https://github.com/omni-us/jsonargparse/issues/480>`__).
+- `Annotated` fields in dataclass-likes (eg FastAPI types) resolve incorrectly
+  (`#480 <https://github.com/omni-us/jsonargparse/issues/480>`__).
+
 
 v4.28.0 (2024-03-??)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,14 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+v4.28.1 (2024-0?-??)
+--------------------
+
+Fixed
+^^^^^
+-  Failure to process ``Annotated`` dataclass members, and inclusion of
+   non-init fields in `attrs` and Pydantic dataclass-like instantiation.
+
 v4.28.0 (2024-03-??)
 --------------------
 
@@ -18,14 +26,6 @@ Added
 ^^^^^
 - Support for "-" as value for Path class initialization so that user
   can ask to use standard input/output instead of file.
-
-v4.27.8 (2024-0?-??)
---------------------
-
-Fixed
-^^^^^
--  Failure to process ``Annotated`` dataclass members, and inclusion of
-   non-init fields in `attrs` and Pydantic dataclass-like instantiation.
 
 v4.27.7 (2024-03-21)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.27.8 (2024-0?-??)
+--------------------
+
+Fixed
+^^^^^
+-  Failure to process ``Annotated`` dataclass members, and inclusion of
+   non-init fields in `attrs` and Pydantic dataclass-like instantiation.
+
 v4.27.7 (2024-03-21)
 --------------------
 

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -445,6 +445,9 @@ Some notes about this support are:
   see :ref:`callable-type`. Currently the callable's argument and return types
   are not validated.
 
+- ``TypeAliasType`` is supported with values parsed as the aliased type and the
+  alias shown as the argument type in help.
+
 
 .. _restricted-numbers:
 

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -21,6 +21,7 @@ from typing import (  # type: ignore[attr-defined]
 from ._namespace import Namespace
 from ._optionals import (
     get_alias_target,
+    get_annotated_base_type,
     import_reconplogger,
     is_alias_type,
     is_annotated,
@@ -110,7 +111,7 @@ def get_unaliased_type(cls):
     while True:
         cur_cls = new_cls
         if is_annotated(new_cls):
-            new_cls = new_cls.__origin__
+            new_cls = get_annotated_base_type(new_cls)
         if is_alias_type(new_cls):
             new_cls = get_alias_target(new_cls)
         if new_cls == cur_cls:

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -22,9 +22,8 @@ from ._namespace import Namespace
 from ._optionals import (
     get_alias_target,
     import_reconplogger,
-    is_annotated,
-    is_annotated_validator,
     is_alias_type,
+    is_annotated,
     reconplogger_support,
 )
 from ._type_checking import ArgumentParser

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -19,7 +19,14 @@ from typing import (  # type: ignore[attr-defined]
 )
 
 from ._namespace import Namespace
-from ._optionals import import_reconplogger, reconplogger_support
+from ._optionals import (
+    get_alias_target,
+    import_reconplogger,
+    is_annotated,
+    is_annotated_validator,
+    is_alias_type,
+    reconplogger_support,
+)
 from ._type_checking import ArgumentParser
 
 __all__ = [
@@ -97,6 +104,20 @@ def is_generic_class(cls) -> bool:
 
 def get_generic_origin(cls):
     return cls.__origin__ if is_generic_class(cls) else cls
+
+
+def get_unaliased_type(cls):
+    new_cls = cls
+    while True:
+        cur_cls = new_cls
+        if is_annotated(new_cls):
+            new_cls = new_cls.__origin__
+        if is_alias_type(new_cls):
+            new_cls = get_alias_target(new_cls)
+        if new_cls == cur_cls:
+            break
+        cur_cls = new_cls
+    return cur_cls
 
 
 def is_dataclass_like(cls) -> bool:

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -115,7 +115,6 @@ def get_unaliased_type(cls):
             new_cls = get_alias_target(new_cls)
         if new_cls == cur_cls:
             break
-        cur_cls = new_cls
     return cur_cls
 
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -37,7 +37,7 @@ _docstring_parse_options = {
 
 def typing_extensions_import(name):
     if typing_extensions_support:
-        return getattr(__import__("typing_extensions"), name)
+        return getattr(__import__("typing_extensions"), name, False)
     else:
         return getattr(__import__("typing"), name, False)
 
@@ -311,6 +311,17 @@ annotated_alias = typing_extensions_import("_AnnotatedAlias")
 
 def is_annotated(typehint: type) -> bool:
     return annotated_alias and isinstance(typehint, annotated_alias)
+
+
+type_alias_type = typing_extensions_import("TypeAliasType")
+
+
+def is_alias_type(typehint: type) -> bool:
+    return type_alias_type and isinstance(typehint, type_alias_type)
+
+
+def get_alias_target(typehint: type) -> bool:
+    return typehint.__value__
 
 
 def get_pydantic_support() -> int:

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -353,7 +353,7 @@ def get_pydantic_supports_field_init() -> bool:
 
             support = pydantic.version.VERSION
         major, minor = tuple(int(x) for x in support.split(".")[:2])
-        return major > 2 or (major == 2 and minor >= 4)
+        return major > 2 or (major == 2 and minor >= 5)
     return False
 
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -321,7 +321,7 @@ def is_alias_type(typehint: type) -> bool:
 
 
 def get_alias_target(typehint: type) -> bool:
-    return typehint.__value__
+    return typehint.__value__  # type: ignore[attr-defined]
 
 
 def get_pydantic_support() -> int:
@@ -350,7 +350,7 @@ def is_pydantic_model(class_type) -> int:
 
             if issubclass(cls, pydantic.BaseModel):
                 return pydantic_support
-            elif pydantic_support > 1 and issubclass(cls, pydantic.v1.BaseModel):
+            elif pydantic_support > 1 and issubclass(cls, pydantic.v1.BaseModel):  # type: ignore[attr-defined]
                 return 1
     return 0
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -350,7 +350,7 @@ def is_pydantic_model(class_type) -> int:
 
             if issubclass(cls, pydantic.BaseModel):
                 return pydantic_support
-            elif pydantic_support > 1 and issubclass(cls, pydantic.v1.BaseModel):  # type: ignore[attr-defined]
+            elif pydantic_support > 1 and issubclass(cls, pydantic.v1.BaseModel):
                 return 1
     return 0
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -353,7 +353,7 @@ def get_pydantic_supports_field_init() -> bool:
 
             support = pydantic.version.VERSION
         major, minor = tuple(int(x) for x in support.split(".")[:2])
-        return major > 2 or (major == 2 and minor >= 5)
+        return major > 2 or (major == 2 and minor >= 6)
     return False
 
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -343,7 +343,6 @@ pydantic_support = get_pydantic_support()
 
 
 def get_pydantic_supports_field_init() -> bool:
-    support = "0"
     if find_spec("pydantic"):
         try:
             from importlib.metadata import version

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -342,6 +342,25 @@ def get_pydantic_support() -> int:
 pydantic_support = get_pydantic_support()
 
 
+def get_pydantic_supports_field_init() -> bool:
+    support = "0"
+    if find_spec("pydantic"):
+        try:
+            from importlib.metadata import version
+
+            support = version("pydantic")
+        except ImportError:
+            import pydantic
+
+            support = pydantic.version.VERSION
+
+    major, minor = tuple(int(x) for x in support.split(".")[:2])
+    return major > 2 or (major == 2 and minor >= 4)
+
+
+pydantic_supports_field_init = get_pydantic_supports_field_init()
+
+
 def is_pydantic_model(class_type) -> int:
     classes = inspect.getmro(class_type) if pydantic_support and inspect.isclass(class_type) else []
     for cls in classes:

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -313,6 +313,10 @@ def is_annotated(typehint: type) -> bool:
     return annotated_alias and isinstance(typehint, annotated_alias)
 
 
+def get_annotated_base_type(typehint: type) -> type:
+    return typehint.__origin__  # type: ignore[attr-defined]
+
+
 type_alias_type = typing_extensions_import("TypeAliasType")
 
 

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -353,9 +353,9 @@ def get_pydantic_supports_field_init() -> bool:
             import pydantic
 
             support = pydantic.version.VERSION
-
-    major, minor = tuple(int(x) for x in support.split(".")[:2])
-    return major > 2 or (major == 2 and minor >= 4)
+        major, minor = tuple(int(x) for x in support.split(".")[:2])
+        return major > 2 or (major == 2 and minor >= 4)
+    return False
 
 
 pydantic_supports_field_init = get_pydantic_supports_field_init()

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -949,11 +949,11 @@ def get_parameters_from_pydantic_or_attrs(
     if pydantic_support:
         pydantic_model = is_pydantic_model(function_or_class)
         if pydantic_model == 1:
-            fields_iterator = function_or_class.__fields__.items()  # type: ignore[union-attr]
+            fields_iterator = function_or_class.__fields__.items()
             get_field_data = get_field_data_pydantic1_model
             is_init_field = is_init_field_default
         elif pydantic_model > 1:
-            fields_iterator = function_or_class.model_fields.items()  # type: ignore[union-attr]
+            fields_iterator = function_or_class.model_fields.items()
             get_field_data = get_field_data_pydantic2_model
             is_init_field = is_init_field_default
         elif dataclasses.is_dataclass(function_or_class) and hasattr(function_or_class, "__pydantic_fields__"):

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -923,10 +923,6 @@ def get_field_data_attrs(field, name, doc_params):
     )
 
 
-def is_init_field_pydantic_model(field) -> bool:
-    return True
-
-
 def is_init_field_pydantic2_dataclass(field) -> bool:
     from pydantic.fields import FieldInfo
 
@@ -956,11 +952,11 @@ def get_parameters_from_pydantic_or_attrs(
         if pydantic_model == 1:
             fields_iterator = function_or_class.__fields__.items()
             get_field_data = get_field_data_pydantic1_model
-            is_init_field = is_init_field_pydantic_model
+            is_init_field = lambda _: True
         elif pydantic_model > 1:
             fields_iterator = function_or_class.model_fields.items()
             get_field_data = get_field_data_pydantic2_model
-            is_init_field = is_init_field_pydantic_model
+            is_init_field = lambda _: True
         elif dataclasses.is_dataclass(function_or_class) and hasattr(function_or_class, "__pydantic_fields__"):
             fields_iterator = dataclasses.fields(function_or_class)
             fields_iterator = {v.name: v for v in fields_iterator}.items()

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -926,7 +926,7 @@ def get_field_data_attrs(field, name, doc_params):
 def is_init_field_pydantic2_dataclass(field) -> Optional[bool]:
     from pydantic.dataclasses import FieldInfo
 
-    if isinstance(field.default, FieldInfo) and hasattr(field.default, 'init'):
+    if isinstance(field.default, FieldInfo) and hasattr(field.default, "init"):
         return field.default.init is not False
     return field.init is not False
 

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -872,6 +872,7 @@ def get_field_data_pydantic2_dataclass(field, name, doc_params):
     from pydantic.dataclasses import FieldInfo
     from pydantic_core import PydanticUndefined
 
+    default = inspect._empty
     if isinstance(field.default, FieldInfo):
         # Pydantic 2 dataclasses stuff their FieldInfo into a
         # stdlib dataclasses.field's `default`; this is where the
@@ -884,8 +885,7 @@ def get_field_data_pydantic2_dataclass(field, name, doc_params):
         default = field.default
     elif field.default_factory is not dataclasses.MISSING:
         default = field.default_factory()
-    else:
-        default = inspect._empty
+
     return dict(
         annotation=field.type,
         default=default,

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -1020,7 +1020,6 @@ def get_signature_parameters(
         visitor = ParametersVisitor(function_or_class, method_or_property, logger=logger)
         return visitor.get_parameters()
     except Exception as ex:
-        print(f"{type(ex).__name__}: {ex}")
         cause = "Source not available"
         exc_info = None
         if not isinstance(ex, SourceNotAvailable):

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -928,7 +928,7 @@ def should_init_field_pydantic2_dataclass(field) -> Optional[bool]:
 
     if isinstance(field.default, FieldInfo):
         return field.default.init
-    return True
+    return field.init
 
 
 def should_init_field_default(field) -> Optional[bool]:

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -936,7 +936,7 @@ def is_init_field_pydantic2_dataclass(field) -> bool:
     return field.init is not False
 
 
-def is_init_field_default(field) -> bool:
+def is_init_field_attrs(field) -> bool:
     return field.init is not False
 
 
@@ -973,7 +973,7 @@ def get_parameters_from_pydantic_or_attrs(
         if attrs.has(function_or_class):
             fields_iterator = {f.name: f for f in attrs.fields(function_or_class)}.items()
             get_field_data = get_field_data_attrs
-            is_init_field = is_init_field_default
+            is_init_field = is_init_field_attrs
 
     if not fields_iterator or not get_field_data:
         return None

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -929,9 +929,10 @@ def is_init_field_pydantic_model(field) -> bool:
 
 def is_init_field_pydantic2_dataclass(field) -> bool:
     from pydantic.fields import FieldInfo
+
     if isinstance(field.default, FieldInfo):
         # FieldInfo.init is new in pydantic 2.6
-        return getattr(field.default, 'init', None) is not False
+        return getattr(field.default, "init", None) is not False
     return field.init is not False
 
 
@@ -1019,7 +1020,7 @@ def get_signature_parameters(
         visitor = ParametersVisitor(function_or_class, method_or_property, logger=logger)
         return visitor.get_parameters()
     except Exception as ex:
-        print(f'{type(ex).__name__}: {ex}')
+        print(f"{type(ex).__name__}: {ex}")
         cause = "Source not available"
         exc_info = None
         if not isinstance(ex, SourceNotAvailable):

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -926,7 +926,7 @@ def get_field_data_attrs(field, name, doc_params):
 def is_init_field_pydantic2_dataclass(field) -> Optional[bool]:
     from pydantic.dataclasses import FieldInfo
 
-    if isinstance(field.default, FieldInfo):
+    if isinstance(field.default, FieldInfo) and hasattr(field.default, 'init'):
         return field.default.init is not False
     return field.init is not False
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
 from ._actions import _ActionConfigLoad
-from ._common import LoggerProperty, get_class_instantiator, get_generic_origin, is_dataclass_like, is_subclass
+from ._common import LoggerProperty, get_class_instantiator, get_generic_origin, get_unaliased_type, is_dataclass_like, is_subclass
 from ._optionals import get_doc_short_description, is_pydantic_model, pydantic_support
 from ._parameter_resolvers import (
     ParamData,
@@ -440,7 +440,7 @@ class SignatureArguments(LoggerProperty):
             if isinstance(default, dict):
                 with suppress(TypeError):
                     default = theclass(**default)
-            if not isinstance(default, theclass):
+            if not isinstance(default, get_unaliased_type(theclass)):
                 raise ValueError(
                     f'Expected "default" argument to be an instance of "{theclass.__name__}" '
                     f"or its kwargs dict, given {default}"

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -8,7 +8,14 @@ from contextlib import suppress
 from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
 from ._actions import _ActionConfigLoad
-from ._common import LoggerProperty, get_class_instantiator, get_generic_origin, get_unaliased_type, is_dataclass_like, is_subclass
+from ._common import (
+    LoggerProperty,
+    get_class_instantiator,
+    get_generic_origin,
+    get_unaliased_type,
+    is_dataclass_like,
+    is_subclass,
+)
 from ._optionals import get_doc_short_description, is_pydantic_model, pydantic_support
 from ._parameter_resolvers import (
     ParamData,

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -79,7 +79,7 @@ class SignatureArguments(LoggerProperty):
             ValueError: When not given a class.
             ValueError: When there are required parameters without at least one valid type.
         """
-        if not inspect.isclass(get_generic_origin(theclass)):
+        if not inspect.isclass(get_generic_origin(get_unaliased_type(theclass))):
             raise ValueError(f'Expected "theclass" parameter to be a class type, got: {theclass}.')
         if default and not (isinstance(default, LazyInitBaseClass) and isinstance(default, theclass)):
             raise ValueError(f'Expected "default" parameter to be a lazy instance of the class, got: {default}.')
@@ -140,9 +140,10 @@ class SignatureArguments(LoggerProperty):
             ValueError: When not given a class or the name of a method of the class.
             ValueError: When there are required parameters without at least one valid type.
         """
-        if not inspect.isclass(get_generic_origin(theclass)):
+        unaliased_type = get_unaliased_type(theclass)
+        if not inspect.isclass(get_generic_origin(unaliased_type)):
             raise ValueError('Expected "theclass" argument to be a class object.')
-        if not hasattr(theclass, themethod) or not callable(getattr(theclass, themethod)):
+        if not hasattr(unaliased_type, themethod) or not callable(getattr(unaliased_type, themethod)):
             raise ValueError('Expected "themethod" argument to be a callable member of the class.')
 
         return self._add_signature_arguments(

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -61,9 +61,9 @@ from ._optionals import (
     argcomplete_warn_redraw_prompt,
     get_alias_target,
     get_files_completer,
+    is_alias_type,
     is_annotated,
     is_annotated_validator,
-    is_alias_type,
     typing_extensions_import,
     validate_annotated,
 )

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -28,6 +28,9 @@ from jsonargparse_tests.conftest import (
     skip_if_docstring_parser_unavailable,
 )
 
+annotated = typing_extensions_import("Annotated")
+type_alias_type = typing_extensions_import("TypeAliasType")
+
 # dataclass tests
 
 
@@ -216,6 +219,8 @@ def test_dataclass_field_init_false(parser):
     added = parser.add_dataclass_arguments(DataInitFalse, "d")
     assert added == ["d.p1"]
     assert parser.get_defaults() == Namespace(d=Namespace(p1="-"))
+    cfg = parser.parse_args(["--d.p1=-"])
+    assert cfg.d.p1 == "-"
 
 
 @dataclasses.dataclass
@@ -468,9 +473,99 @@ def test_add_class_final(parser):
     pytest.raises(ValueError, lambda: parser.add_class_arguments(FinalClass, "a", default=FinalClass()))
 
 
-# pydantic tests
+if type_alias_type:
+    StringOrInt = type_alias_type('StringOrInt', Union[str, int])
 
-annotated = typing_extensions_import("Annotated")
+    @dataclasses.dataclass
+    class DataClassWithAliasType:
+        p1: StringOrInt
+
+    def test_bare_alias_type(parser):
+        parser.add_argument("--data", type=StringOrInt)
+        cfg = parser.parse_args(["--data=MyString"])
+        assert cfg.data == "MyString"
+        cfg = parser.parse_args(["--data=3"])
+        assert cfg.data == 3
+
+    def test_dataclass_with_alias_type(parser):
+        parser.add_argument("--data", type=DataClassWithAliasType)
+        cfg = parser.parse_args(["--data.p1=MyString"])
+        assert cfg.data.p1 == "MyString"
+        cfg = parser.parse_args(["--data.p1=3"])
+        assert cfg.data.p1 == 3
+
+    @pytest.mark.skipif(not annotated, reason="Annotated is required")
+    def test_annotated_alias_type(parser):
+        parser.add_argument("--data", type=annotated[StringOrInt, 1])
+        cfg = parser.parse_args(["--data=MyString"])
+        assert cfg.data == "MyString"
+        cfg = parser.parse_args(["--data=3"])
+        assert cfg.data == 3
+
+    if annotated:
+        @dataclasses.dataclass
+        class DataClassWithAnnotatedAliasType:
+            p1: annotated[StringOrInt, 1]
+
+    @pytest.mark.skipif(not annotated, reason="Annotated is required")
+    def test_dataclass_with_annotated_alias_type(parser):
+        parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
+        cfg = parser.parse_args(["--data.p1=MyString"])
+        assert cfg.data.p1 == "MyString"
+        cfg = parser.parse_args(["--data.p1=3"])
+        assert cfg.data.p1 == 3
+
+
+# pydantic tests
+if annotated and pydantic_support > 1:
+    import pydantic.dataclasses
+
+    @pydantic.dataclasses.dataclass(frozen=True)
+    class InnerDataClass:
+        """DataClass description
+
+        Args:
+            a1: a1 help
+        """
+
+        a1: int = 1
+
+    @pydantic.dataclasses.dataclass(frozen=True)
+    class NestedAnnotatedDataClass:
+        """NestedAnnotatedDataClass description
+
+        Args:
+            a1: a1 help
+        """
+
+        a1: annotated[InnerDataClass, 1]
+
+    @pydantic.dataclasses.dataclass(frozen=True)
+    class NestedAnnotatedDataClassWithDefaultFactory:
+        """NestedAnnotatedDataClass description
+
+        Args:
+            a1: a1 help
+        """
+
+        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(
+            default_factory=InnerDataClass)
+
+    def test_pydantic_nested_annotated_dataclass(parser: ArgumentParser):
+        parser.add_class_arguments(NestedAnnotatedDataClass, "n")
+        parser.parse_args(["--n.a1.a1=1"])
+
+    def test_pydantic_annotated_nested_annotated_dataclass(parser: ArgumentParser):
+        parser.add_class_arguments(annotated[NestedAnnotatedDataClass, 1], "n")
+        parser.parse_args(["--n.a1.a1=1"])
+
+    def test_pydantic_annotated_nested_annotated_dataclass_with_default(
+            parser: ArgumentParser):
+        parser.add_class_arguments(annotated[
+            NestedAnnotatedDataClassWithDefaultFactory, 1], "n")
+        parser.parse_args(["--n.a1.a1=1"])
+
+
 length = "length"
 if pydantic_support:
     import pydantic
@@ -479,6 +574,15 @@ if pydantic_support:
     class PydanticData:
         p1: float = 0.1
         p2: str = "-"
+
+    @pydantic.dataclasses.dataclass
+    class PydanticDataNested:
+        p3: PydanticData
+
+    @pydantic.dataclasses.dataclass
+    class PydanticDataFieldInitFalse:
+        p1: float = 0.1
+        p2: str = pydantic.dataclasses.Field("-", init=False)
 
     class PydanticModel(pydantic.BaseModel):
         p1: str
@@ -587,6 +691,27 @@ class TestPydantic:
             parser.parse_args([f"--model.param={invalid_value}"])
         ctx.match("model.param")
 
+    def test_dataclass_field_init_false(self, parser):
+        # This tests the following error:
+        #
+        # TypeError: Parser key "data.p2":
+        # Expected a <class 'str'>. Got value: annotation=str
+        # required=False default='-' init=False
+        parser.add_argument("--data", type=PydanticDataFieldInitFalse)
+        print(parser.get_defaults())
+        cfg = parser.parse_args(["--data.p1=1.0"])
+        assert cfg.data.p1 == 1.0
+
+    def test_dataclass_nested(self, parser):
+        # This tests the following error:
+        #
+        # ValueError: Expected "default" argument to be an instance of
+        # "PydanticData" or its kwargs dict, given
+        # <dataclasses._MISSING_TYPE object at 0x105624c50>
+
+        parser.add_argument("--data", type=PydanticDataNested)
+        cfg = parser.parse_args(["--data", '{"p3": {"p1": 1.0}}'])
+
 
 # attrs tests
 
@@ -605,6 +730,14 @@ if attrs_support:
     @attrs.define
     class AttrsFieldFactory:
         p1: List[str] = attrs.field(factory=lambda: ["one", "two"])
+
+    @attrs.define
+    class AttrsFieldInitFalse:
+        p1: float
+        p2: dict = attrs.field(init=False)
+
+        def __attrs_post_init__(self):
+            self.p2 = {}
 
 
 @pytest.mark.skipif(not attrs_support, reason="attrs package is required")
@@ -628,3 +761,13 @@ class TestAttrs:
         assert cfg1.data.p1 == ["one", "two"]
         assert cfg1.data.p1 == cfg2.data.p1
         assert cfg1.data.p1 is not cfg2.data.p1
+
+    def test_field_init_false(self, parser):
+        # This tests the following error:
+        #
+        # TypeError('Validation failed: Key "data.p2" is required but
+        # not included in config object or its value is None.')
+
+        parser.add_argument("--data", type=AttrsFieldInitFalse)
+        cfg = parser.parse_args(["--data.p1=1.0"])
+        assert cfg.data.p1 == 1.0

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -800,7 +800,7 @@ class TestAttrs:
     def test_field_init_false(self, parser):
         # Prior to PR #480, this test would produce the following error:
         #
-        # TypeError('Validation failed: Key "data.p2" is required but
+        # TypeError('Validation failed: Key "data.p1" is required but
         # not included in config object or its value is None.')
 
         parser.add_argument("--data", type=AttrsFieldInitFalse)

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -549,7 +549,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default=InnerDataClass())  # type: ignore[valid-type]
+        a1: annotated[InnerDataClass, 1] = pydantic.fields.Field(default=InnerDataClass())  # type: ignore[valid-type]
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefaultFactory:
@@ -559,7 +559,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default_factory=InnerDataClass)  # type: ignore[valid-type]
+        a1: annotated[InnerDataClass, 1] = pydantic.fields.Field(default_factory=InnerDataClass)  # type: ignore[valid-type]
 
     def test_pydantic_nested_annotated_dataclass(parser: ArgumentParser):
         parser.add_class_arguments(NestedAnnotatedDataClass, "n")
@@ -594,7 +594,7 @@ if pydantic_support:
     @pydantic.dataclasses.dataclass
     class PydanticDataFieldInitFalse:
         p1: float = 0.1
-        p2: str = pydantic.dataclasses.Field("-", init=False)
+        p2: str = pydantic.Field("-", init=False)
 
     class PydanticModel(pydantic.BaseModel):
         p1: str

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -589,6 +589,12 @@ if pydantic_support:
         p3: PydanticData
 
     if pydantic_supports_field_init:
+        import logging
+        support = pydantic.version.VERSION
+        major, minor = tuple(int(x) for x in support.split(".")[:2])
+        logging.basicConfig()
+        print(f'{support}, {major}, {minor}')
+        
         from pydantic.dataclasses import dataclass as pydantic_v2_dataclass
         from pydantic.fields import Field as PydanticV2Field
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -494,8 +494,7 @@ if type_alias_type:
     def test_dataclass_with_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n")
-                          if "IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
@@ -507,8 +506,7 @@ if type_alias_type:
     def test_annotated_alias_type(parser):
         parser.add_argument("--data", type=annotated[IntOrString, 1])
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n")
-                          if "IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
@@ -526,8 +524,7 @@ if type_alias_type:
     def test_dataclass_with_annotated_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n")
-                          if "IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
         print(help_str)
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -474,7 +474,7 @@ def test_add_class_final(parser):
 
 
 if type_alias_type:
-    IntOrString = type_alias_type('IntOrString', Union[int, str])
+    IntOrString = type_alias_type("IntOrString", Union[int, str])
 
     @dataclasses.dataclass
     class DataClassWithAliasType:
@@ -503,6 +503,7 @@ if type_alias_type:
         assert cfg.data == 3
 
     if annotated:
+
         @dataclasses.dataclass
         class DataClassWithAnnotatedAliasType:
             p1: annotated[IntOrString, 1]
@@ -541,6 +542,16 @@ if annotated and pydantic_support > 1:
         a1: annotated[InnerDataClass, 1]
 
     @pydantic.dataclasses.dataclass(frozen=True)
+    class NestedAnnotatedDataClassWithDefault:
+        """NestedAnnotatedDataClass description
+
+        Args:
+            a1: a1 help
+        """
+
+        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default=InnerDataClass())
+
+    @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefaultFactory:
         """NestedAnnotatedDataClass description
 
@@ -548,8 +559,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(
-            default_factory=InnerDataClass)
+        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default_factory=InnerDataClass)
 
     def test_pydantic_nested_annotated_dataclass(parser: ArgumentParser):
         parser.add_class_arguments(NestedAnnotatedDataClass, "n")
@@ -559,10 +569,12 @@ if annotated and pydantic_support > 1:
         parser.add_class_arguments(annotated[NestedAnnotatedDataClass, 1], "n")
         parser.parse_args(["--n.a1.a1=1"])
 
-    def test_pydantic_annotated_nested_annotated_dataclass_with_default(
-            parser: ArgumentParser):
-        parser.add_class_arguments(annotated[
-            NestedAnnotatedDataClassWithDefaultFactory, 1], "n")
+    def test_pydantic_annotated_nested_annotated_dataclass_with_default(parser: ArgumentParser):
+        parser.add_class_arguments(annotated[NestedAnnotatedDataClassWithDefault, 1], "n")
+        parser.parse_args(["--n.a1.a1=1"])
+
+    def test_pydantic_annotated_nested_annotated_dataclass_with_default_factory(parser: ArgumentParser):
+        parser.add_class_arguments(annotated[NestedAnnotatedDataClassWithDefaultFactory, 1], "n")
         parser.parse_args(["--n.a1.a1=1"])
 
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -602,14 +602,14 @@ if pydantic_support:
             p2: str = PydanticV2Field("-", init=False)
 
     @pydantic.dataclasses.dataclass
-    class PydanticDataStdlibFieldInitFalse:
+    class PydanticDataStdlibField:
         p1: float = 0.1
-        p2: str = dataclasses.field(default="-", init=False)
+        p2: str = dataclasses.field(default="-")
 
     @pydantic.dataclasses.dataclass
-    class PydanticDataStdlibFieldInitFalseWithFactory:
+    class PydanticDataStdlibFieldWithFactory:
         p1: float = 0.1
-        p2: str = dataclasses.field(default_factory=lambda: "-", init=False)
+        p2: str = dataclasses.field(default_factory=lambda: "-")
 
     class PydanticModel(pydantic.BaseModel):
         p1: str
@@ -729,13 +729,13 @@ class TestPydantic:
         cfg = parser.parse_args(["--data.p1=1.0"])
         assert cfg.data.p1 == 1.0
 
-    def test_dataclass_stdlib_field_init_false(self, parser):
-        parser.add_argument("--data", type=PydanticDataStdlibFieldInitFalse)
+    def test_dataclass_stdlib_field(self, parser):
+        parser.add_argument("--data", type=PydanticDataStdlibField)
         cfg = parser.parse_args(["--data.p1=1.0"])
         assert cfg.data.p1 == 1.0
 
-    def test_dataclass_stdlib_field_init_false_with_factory(self, parser):
-        parser.add_argument("--data", type=PydanticDataStdlibFieldInitFalseWithFactory)
+    def test_dataclass_stdlib_field_init_with_factory(self, parser):
+        parser.add_argument("--data", type=PydanticDataStdlibFieldWithFactory)
         cfg = parser.parse_args(["--data.p1=1.0"])
         assert cfg.data.p1 == 1.0
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -601,6 +601,16 @@ if pydantic_support:
             p1: float = 0.1
             p2: str = PydanticV2Field("-", init=False)
 
+    @pydantic.dataclasses.dataclass
+    class PydanticDataStdlibFieldInitFalse:
+        p1: float = 0.1
+        p2: str = dataclasses.field(default="-", init=False)
+
+    @pydantic.dataclasses.dataclass
+    class PydanticDataStdlibFieldInitFalseWithFactory:
+        p1: float = 0.1
+        p2: str = dataclasses.field(default_factory=lambda: "-", init=False)
+
     class PydanticModel(pydantic.BaseModel):
         p1: str
         p2: int = 3
@@ -716,6 +726,16 @@ class TestPydantic:
         # Expected a <class 'str'>. Got value: annotation=str
         # required=False default='-' init=False
         parser.add_argument("--data", type=PydanticDataFieldInitFalse)
+        cfg = parser.parse_args(["--data.p1=1.0"])
+        assert cfg.data.p1 == 1.0
+
+    def test_dataclass_stdlib_field_init_false(self, parser):
+        parser.add_argument("--data", type=PydanticDataStdlibFieldInitFalse)
+        cfg = parser.parse_args(["--data.p1=1.0"])
+        assert cfg.data.p1 == 1.0
+
+    def test_dataclass_stdlib_field_init_false_with_factory(self, parser):
+        parser.add_argument("--data", type=PydanticDataStdlibFieldInitFalseWithFactory)
         cfg = parser.parse_args(["--data.p1=1.0"])
         assert cfg.data.p1 == 1.0
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -494,7 +494,7 @@ if type_alias_type:
     def test_dataclass_with_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
@@ -506,7 +506,7 @@ if type_alias_type:
     def test_annotated_alias_type(parser):
         parser.add_argument("--data", type=annotated[IntOrString, 1])
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: Annotated[IntOrString, 1]" in line]
         assert len(help_str_lines) == 1
         assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
@@ -524,8 +524,8 @@ if type_alias_type:
     def test_dataclass_with_annotated_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "IntOrString" in line]
-        print(help_str)
+        # The printable field datatype is not uniform across versions.
+        help_str_lines = [line for line in help_str.split("\n") if "type:" in line and "IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
@@ -806,7 +806,6 @@ class TestAttrs:
         parser.add_argument("--data", type=AttrsFieldInitFalse)
         cfg = parser.parse_args(["--data", "{}"])
         help_str = get_parser_help(parser)
-        print(help_str)
         assert "--data.p1" not in help_str
         assert cfg.data == Namespace()
         cfg = parser.instantiate_classes(cfg)

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -594,7 +594,7 @@ if pydantic_support:
         major, minor = tuple(int(x) for x in support.split(".")[:2])
         logging.basicConfig()
         print(f'{support}, {major}, {minor}')
-        
+
         from pydantic.dataclasses import dataclass as pydantic_v2_dataclass
         from pydantic.fields import Field as PydanticV2Field
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -483,8 +483,7 @@ if type_alias_type:
     def test_bare_alias_type(parser):
         parser.add_argument("--data", type=IntOrString)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split('\n')
-                          if 'type: IntOrString' in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
@@ -495,8 +494,7 @@ if type_alias_type:
     def test_dataclass_with_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split('\n')
-                          if 'type: IntOrString' in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
@@ -508,8 +506,7 @@ if type_alias_type:
     def test_annotated_alias_type(parser):
         parser.add_argument("--data", type=annotated[IntOrString, 1])
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split('\n')
-                          if 'type: Annotated[IntOrString, 1]' in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: Annotated[IntOrString, 1]" in line]
         assert len(help_str_lines) == 1
         assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
@@ -527,8 +524,7 @@ if type_alias_type:
     def test_dataclass_with_annotated_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split('\n')
-                          if 'type: IntOrString' in line]
+        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
         print(help_str)
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -478,7 +478,7 @@ if type_alias_type:
 
     @dataclasses.dataclass
     class DataClassWithAliasType:
-        p1: IntOrString
+        p1: IntOrString  # type: ignore[valid-type]
 
     def test_bare_alias_type(parser):
         parser.add_argument("--data", type=IntOrString)
@@ -506,7 +506,7 @@ if type_alias_type:
 
         @dataclasses.dataclass
         class DataClassWithAnnotatedAliasType:
-            p1: annotated[IntOrString, 1]
+            p1: annotated[IntOrString, 1]  # type: ignore[valid-type]
 
     @pytest.mark.skipif(not annotated, reason="Annotated is required")
     def test_dataclass_with_annotated_alias_type(parser):
@@ -539,7 +539,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1]
+        a1: annotated[InnerDataClass, 1]  # type: ignore[valid-type]
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefault:
@@ -549,7 +549,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default=InnerDataClass())
+        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default=InnerDataClass())  # type: ignore[valid-type]
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefaultFactory:
@@ -559,7 +559,7 @@ if annotated and pydantic_support > 1:
             a1: a1 help
         """
 
-        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default_factory=InnerDataClass)
+        a1: annotated[InnerDataClass, 1] = pydantic.dataclasses.Field(default_factory=InnerDataClass)  # type: ignore[valid-type]
 
     def test_pydantic_nested_annotated_dataclass(parser: ArgumentParser):
         parser.add_class_arguments(NestedAnnotatedDataClass, "n")

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -710,7 +710,6 @@ class TestPydantic:
         # Expected a <class 'str'>. Got value: annotation=str
         # required=False default='-' init=False
         parser.add_argument("--data", type=PydanticDataFieldInitFalse)
-        print(parser.get_defaults())
         cfg = parser.parse_args(["--data.p1=1.0"])
         assert cfg.data.p1 == 1.0
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -212,16 +212,15 @@ def test_add_argument_dataclass_type_required_attr(parser):
 
 @dataclasses.dataclass
 class DataInitFalse:
-    p1: str = "-"
-    p2: str = dataclasses.field(init=False)
+    p1: str = dataclasses.field(init=False)
 
 
 def test_dataclass_field_init_false(parser):
     added = parser.add_dataclass_arguments(DataInitFalse, "d")
-    assert added == ["d.p1"]
-    assert parser.get_defaults() == Namespace(d=Namespace(p1="-"))
-    cfg = parser.parse_args(["--d.p1=-"])
-    assert cfg.d.p1 == "-"
+    assert added == []
+    assert parser.get_defaults() == Namespace()
+    cfg = parser.parse_args(["--d", "{}"])
+    assert cfg.d == Namespace()
 
 
 @dataclasses.dataclass
@@ -483,6 +482,11 @@ if type_alias_type:
 
     def test_bare_alias_type(parser):
         parser.add_argument("--data", type=IntOrString)
+        help_str = get_parser_help(parser)
+        help_str_lines = [line for line in help_str.split('\n')
+                          if 'type: IntOrString' in line]
+        assert len(help_str_lines) == 1
+        assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
         assert cfg.data == "MyString"
         cfg = parser.parse_args(["--data=3"])
@@ -490,6 +494,11 @@ if type_alias_type:
 
     def test_dataclass_with_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAliasType)
+        help_str = get_parser_help(parser)
+        help_str_lines = [line for line in help_str.split('\n')
+                          if 'type: IntOrString' in line]
+        assert len(help_str_lines) == 1
+        assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
         assert cfg.data.p1 == "MyString"
         cfg = parser.parse_args(["--data.p1=3"])
@@ -498,6 +507,11 @@ if type_alias_type:
     @pytest.mark.skipif(not annotated, reason="Annotated is required")
     def test_annotated_alias_type(parser):
         parser.add_argument("--data", type=annotated[IntOrString, 1])
+        help_str = get_parser_help(parser)
+        help_str_lines = [line for line in help_str.split('\n')
+                          if 'type: Annotated[IntOrString, 1]' in line]
+        assert len(help_str_lines) == 1
+        assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
         assert cfg.data == "MyString"
         cfg = parser.parse_args(["--data=3"])
@@ -512,6 +526,12 @@ if type_alias_type:
     @pytest.mark.skipif(not annotated, reason="Annotated is required")
     def test_dataclass_with_annotated_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
+        help_str = get_parser_help(parser)
+        help_str_lines = [line for line in help_str.split('\n')
+                          if 'type: IntOrString' in line]
+        print(help_str)
+        assert len(help_str_lines) == 1
+        assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
         assert cfg.data.p1 == "MyString"
         cfg = parser.parse_args(["--data.p1=3"])
@@ -524,59 +544,39 @@ if annotated and pydantic_support > 1:
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class InnerDataClass:
-        """DataClass description
-
-        Args:
-            a1: a1 help
-        """
-
-        a1: int = 1
+        a2: int = 1
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClass:
-        """NestedAnnotatedDataClass description
-
-        Args:
-            a1: a1 help
-        """
-
         a1: annotated[InnerDataClass, 1]  # type: ignore[valid-type]
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefault:
-        """NestedAnnotatedDataClass description
-
-        Args:
-            a1: a1 help
-        """
-
         a1: annotated[InnerDataClass, 1] = pydantic.fields.Field(default=InnerDataClass())  # type: ignore[valid-type]
 
     @pydantic.dataclasses.dataclass(frozen=True)
     class NestedAnnotatedDataClassWithDefaultFactory:
-        """NestedAnnotatedDataClass description
-
-        Args:
-            a1: a1 help
-        """
-
         a1: annotated[InnerDataClass, 1] = pydantic.fields.Field(default_factory=InnerDataClass)  # type: ignore[valid-type]
 
     def test_pydantic_nested_annotated_dataclass(parser: ArgumentParser):
         parser.add_class_arguments(NestedAnnotatedDataClass, "n")
-        parser.parse_args(["--n.a1.a1=1"])
+        cfg = parser.parse_args(["--n", "{}"])
+        assert cfg.n == Namespace(a1=Namespace(a2=1))
 
     def test_pydantic_annotated_nested_annotated_dataclass(parser: ArgumentParser):
         parser.add_class_arguments(annotated[NestedAnnotatedDataClass, 1], "n")
-        parser.parse_args(["--n.a1.a1=1"])
+        cfg = parser.parse_args(["--n", "{}"])
+        assert cfg.n == Namespace(a1=Namespace(a2=1))
 
     def test_pydantic_annotated_nested_annotated_dataclass_with_default(parser: ArgumentParser):
         parser.add_class_arguments(annotated[NestedAnnotatedDataClassWithDefault, 1], "n")
-        parser.parse_args(["--n.a1.a1=1"])
+        cfg = parser.parse_args(["--n", "{}"])
+        assert cfg.n == Namespace(a1=Namespace(a2=1))
 
     def test_pydantic_annotated_nested_annotated_dataclass_with_default_factory(parser: ArgumentParser):
         parser.add_class_arguments(annotated[NestedAnnotatedDataClassWithDefaultFactory, 1], "n")
-        parser.parse_args(["--n.a1.a1=1"])
+        cfg = parser.parse_args(["--n", "{}"])
+        assert cfg.n == Namespace(a1=Namespace(a2=1))
 
 
 length = "length"
@@ -598,18 +598,15 @@ if pydantic_support:
 
         @pydantic_v2_dataclass
         class PydanticDataFieldInitFalse:
-            p1: float = 0.1
-            p2: str = PydanticV2Field("-", init=False)
+            p1: str = PydanticV2Field("-", init=False)
 
     @pydantic.dataclasses.dataclass
     class PydanticDataStdlibField:
-        p1: float = 0.1
-        p2: str = dataclasses.field(default="-")
+        p1: str = dataclasses.field(default="-")
 
     @pydantic.dataclasses.dataclass
     class PydanticDataStdlibFieldWithFactory:
-        p1: float = 0.1
-        p2: str = dataclasses.field(default_factory=lambda: "-")
+        p1: str = dataclasses.field(default_factory=lambda: "-")
 
     class PydanticModel(pydantic.BaseModel):
         p1: str
@@ -720,34 +717,40 @@ class TestPydantic:
 
     @pytest.mark.skipif(not pydantic_supports_field_init, reason="Field.init is required")
     def test_dataclass_field_init_false(self, parser):
-        # This tests the following error:
+        # Prior to PR #480, this test would produce the following error:
         #
-        # TypeError: Parser key "data.p2":
+        # TypeError: Parser key "data.p1":
         # Expected a <class 'str'>. Got value: annotation=str
         # required=False default='-' init=False
         parser.add_argument("--data", type=PydanticDataFieldInitFalse)
-        cfg = parser.parse_args(["--data.p1=1.0"])
-        assert cfg.data.p1 == 1.0
+        help_str = get_parser_help(parser)
+        assert "--data.p1" not in help_str
+        cfg = parser.parse_args(["--data", "{}"])
+        assert cfg.data == Namespace()
+
+        cfg = parser.instantiate_classes(cfg)
+        assert cfg.data.p1 == "-"
 
     def test_dataclass_stdlib_field(self, parser):
         parser.add_argument("--data", type=PydanticDataStdlibField)
-        cfg = parser.parse_args(["--data.p1=1.0"])
-        assert cfg.data.p1 == 1.0
+        cfg = parser.parse_args(["--data", "{}"])
+        assert cfg.data == Namespace(p1="-")
 
     def test_dataclass_stdlib_field_init_with_factory(self, parser):
         parser.add_argument("--data", type=PydanticDataStdlibFieldWithFactory)
-        cfg = parser.parse_args(["--data.p1=1.0"])
-        assert cfg.data.p1 == 1.0
+        cfg = parser.parse_args(["--data", "{}"])
+        assert cfg.data == Namespace(p1="-")
 
     def test_dataclass_nested(self, parser):
-        # This tests the following error:
+        # Prior to PR #480, this test would produce the following error:
         #
         # ValueError: Expected "default" argument to be an instance of
         # "PydanticData" or its kwargs dict, given
         # <dataclasses._MISSING_TYPE object at 0x105624c50>
 
         parser.add_argument("--data", type=PydanticDataNested)
-        parser.parse_args(["--data", '{"p3": {"p1": 1.0}}'])
+        cfg = parser.parse_args(["--data", '{"p3": {"p1": 1.0}}'])
+        assert cfg.data == Namespace(p3=Namespace(p1=1.0, p2="-"))
 
 
 # attrs tests
@@ -770,11 +773,10 @@ if attrs_support:
 
     @attrs.define
     class AttrsFieldInitFalse:
-        p1: float
-        p2: dict = attrs.field(init=False)
+        p1: dict = attrs.field(init=False)
 
         def __attrs_post_init__(self):
-            self.p2 = {}
+            self.p1 = {}
 
 
 @pytest.mark.skipif(not attrs_support, reason="attrs package is required")
@@ -800,11 +802,16 @@ class TestAttrs:
         assert cfg1.data.p1 is not cfg2.data.p1
 
     def test_field_init_false(self, parser):
-        # This tests the following error:
+        # Prior to PR #480, this test would produce the following error:
         #
         # TypeError('Validation failed: Key "data.p2" is required but
         # not included in config object or its value is None.')
 
         parser.add_argument("--data", type=AttrsFieldInitFalse)
-        cfg = parser.parse_args(["--data.p1=1.0"])
-        assert cfg.data.p1 == 1.0
+        cfg = parser.parse_args(["--data", "{}"])
+        help_str = get_parser_help(parser)
+        print(help_str)
+        assert "--data.p1" not in help_str
+        assert cfg.data == Namespace()
+        cfg = parser.instantiate_classes(cfg)
+        assert cfg.data.p1 == {}

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -589,12 +589,6 @@ if pydantic_support:
         p3: PydanticData
 
     if pydantic_supports_field_init:
-        import logging
-        support = pydantic.version.VERSION
-        major, minor = tuple(int(x) for x in support.split(".")[:2])
-        logging.basicConfig()
-        print(f'{support}, {major}, {minor}')
-
         from pydantic.dataclasses import dataclass as pydantic_v2_dataclass
         from pydantic.fields import Field as PydanticV2Field
 

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -721,7 +721,7 @@ class TestPydantic:
         # <dataclasses._MISSING_TYPE object at 0x105624c50>
 
         parser.add_argument("--data", type=PydanticDataNested)
-        cfg = parser.parse_args(["--data", '{"p3": {"p1": 1.0}}'])
+        parser.parse_args(["--data", '{"p3": {"p1": 1.0}}'])
 
 
 # attrs tests

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -494,7 +494,8 @@ if type_alias_type:
     def test_dataclass_with_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n")
+                          if "IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]
         cfg = parser.parse_args(["--data.p1=MyString"])
@@ -506,7 +507,8 @@ if type_alias_type:
     def test_annotated_alias_type(parser):
         parser.add_argument("--data", type=annotated[IntOrString, 1])
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "type: Annotated[IntOrString, 1]" in line]
+        help_str_lines = [line for line in help_str.split("\n")
+                          if "IntOrString" in line]
         assert len(help_str_lines) == 1
         assert "--data DATA" in help_str_lines[0]
         cfg = parser.parse_args(["--data=MyString"])
@@ -524,7 +526,8 @@ if type_alias_type:
     def test_dataclass_with_annotated_alias_type(parser):
         parser.add_argument("--data", type=DataClassWithAnnotatedAliasType)
         help_str = get_parser_help(parser)
-        help_str_lines = [line for line in help_str.split("\n") if "type: IntOrString" in line]
+        help_str_lines = [line for line in help_str.split("\n")
+                          if "IntOrString" in line]
         print(help_str)
         assert len(help_str_lines) == 1
         assert "--data.p1 P1" in help_str_lines[0]

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -474,14 +474,14 @@ def test_add_class_final(parser):
 
 
 if type_alias_type:
-    StringOrInt = type_alias_type('StringOrInt', Union[str, int])
+    IntOrString = type_alias_type('IntOrString', Union[int, str])
 
     @dataclasses.dataclass
     class DataClassWithAliasType:
-        p1: StringOrInt
+        p1: IntOrString
 
     def test_bare_alias_type(parser):
-        parser.add_argument("--data", type=StringOrInt)
+        parser.add_argument("--data", type=IntOrString)
         cfg = parser.parse_args(["--data=MyString"])
         assert cfg.data == "MyString"
         cfg = parser.parse_args(["--data=3"])
@@ -496,7 +496,7 @@ if type_alias_type:
 
     @pytest.mark.skipif(not annotated, reason="Annotated is required")
     def test_annotated_alias_type(parser):
-        parser.add_argument("--data", type=annotated[StringOrInt, 1])
+        parser.add_argument("--data", type=annotated[IntOrString, 1])
         cfg = parser.parse_args(["--data=MyString"])
         assert cfg.data == "MyString"
         cfg = parser.parse_args(["--data=3"])
@@ -505,7 +505,7 @@ if type_alias_type:
     if annotated:
         @dataclasses.dataclass
         class DataClassWithAnnotatedAliasType:
-            p1: annotated[StringOrInt, 1]
+            p1: annotated[IntOrString, 1]
 
     @pytest.mark.skipif(not annotated, reason="Annotated is required")
     def test_dataclass_with_annotated_alias_type(parser):

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -595,6 +595,7 @@ if pydantic_support:
     if pydantic_supports_field_init:
         from pydantic.dataclasses import dataclass as pydantic_v2_dataclass
         from pydantic.fields import Field as PydanticV2Field
+
         @pydantic_v2_dataclass
         class PydanticDataFieldInitFalse:
             p1: float = 0.1
@@ -707,7 +708,7 @@ class TestPydantic:
             parser.parse_args([f"--model.param={invalid_value}"])
         ctx.match("model.param")
 
-    @pytest.mark.skipif(not pydantic_supports_field_init, reason='Field.init is required')
+    @pytest.mark.skipif(not pydantic_supports_field_init, reason="Field.init is required")
     def test_dataclass_field_init_false(self, parser):
         # This tests the following error:
         #


### PR DESCRIPTION
## What does this PR do?
This PR includes a few small, related fixes for non-stdlib (possibly annotated) dataclasses and 3.12-style type aliases:
* Exclude non-init fields from `attrs` class instantiation.
* Exclude non-init fields from Pydantic 2 dataclass instantiation.
* Fix initialization for Pydantic 2 dataclasses with default values/factories.
* Look at underlying type for `Annotated` types where needed.
* Look at target for new `TypeAliasType` where needed. (This and the prior are commonly used with FastAPI)
* Tests showing the above were broken and are now fixed.

## Before submitting

- [X] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [X] Did you update **the documentation**? (readme and public docstrings)
- [X] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [X] Did you verify that new and existing **tests pass locally**?
- [X] Did you make sure that all changes preserve **backward compatibility**?
- [X] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
