### PR TITLE
Account for breaking change in argparse.ArgumentParser._parse_optional affecting python 3.11.9 and likely >=3.13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+
 v4.28.0 (2024-03-??)
 --------------------
 
@@ -18,6 +19,13 @@ Added
 ^^^^^
 - Support for "-" as value for Path class initialization so that user
   can ask to use standard input/output instead of file.
+
+Fixed
+^^^^^
+- Account for breaking change in ``argparse.ArgumentParser._parse_optional``
+  affecting python ``3.11.9`` and likely ``>3.13`` (`#484
+  <https://github.com/omni-us/jsonargparse/issues/484>`__).
+
 
 v4.27.7 (2024-03-21)
 --------------------

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -265,12 +265,13 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         return namespace, args
 
     def _parse_optional(self, arg_string):
-        subclass_arg = ActionTypeHint.parse_argv_item(arg_string)
-        if subclass_arg:
-            return subclass_arg
         if arg_string == self._print_config:
             arg_string += "="
-        return super()._parse_optional(arg_string)
+        arg_parsed = super()._parse_optional(arg_string)
+        subclass_arg = ActionTypeHint.parse_argv_item(arg_string, arg_parsed)
+        if subclass_arg:
+            return subclass_arg
+        return arg_parsed
 
     def _parse_common(
         self,

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -332,18 +332,21 @@ class ActionTypeHint(Action):
         return result
 
     @staticmethod
-    def parse_argv_item(arg_string):
+    def parse_argv_item(arg_string, arg_parsed):
         parser = subclass_arg_parser.get()
         action = None
+        sep = None
         if arg_string.startswith("--"):
             arg_base, explicit_arg = (arg_string, None)
             if "=" in arg_string:
-                arg_base, explicit_arg = arg_string.split("=", 1)
+                arg_base, sep, explicit_arg = arg_string.partition("=")
             if "." in arg_base and arg_base not in parser._option_string_actions:
                 action = _find_parent_action(parser, arg_base[2:])
 
         typehint = typehint_from_action(action)
         if typehint:
+            if len(arg_parsed) == 4:
+                return action, arg_base, sep, explicit_arg
             return action, arg_base, explicit_arg
         return None
 

--- a/jsonargparse_tests/test_argcomplete.py
+++ b/jsonargparse_tests/test_argcomplete.py
@@ -26,6 +26,8 @@ from jsonargparse_tests.conftest import (
 def skip_if_argcomplete_unavailable():
     if not find_spec("argcomplete"):
         pytest.skip("argcomplete package is required")
+    if sys.version_info[:2] == (3, 11):
+        pytest.skip("argcomplete is not compatible with Python 3.11, https://github.com/kislyuk/argcomplete/issues/481")
 
 
 @contextmanager


### PR DESCRIPTION
## What does this PR do?

Fixes #484

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
