### PR TITLE
Disable argcomplete tests also in python >= 3.12.3 and update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,12 @@ repos:
     exclude: .bumpversion.cfg
 
 - repo: https://github.com/psf/black
-  rev: 24.2.0
+  rev: 24.3.0
   hooks:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.1
+  rev: v0.3.7
   hooks:
   - id: ruff
     args: ["--fix"]
@@ -40,14 +40,14 @@ repos:
   - id: yesqa
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.18.2
+  rev: v1.20.7
   hooks:
   - id: typos
     args: []
     verbose: true
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: mypy
     files: jsonargparse.*/.*.py

--- a/jsonargparse_tests/test_argcomplete.py
+++ b/jsonargparse_tests/test_argcomplete.py
@@ -26,8 +26,11 @@ from jsonargparse_tests.conftest import (
 def skip_if_argcomplete_unavailable():
     if not find_spec("argcomplete"):
         pytest.skip("argcomplete package is required")
-    if sys.version_info[:2] == (3, 11):
-        pytest.skip("argcomplete is not compatible with Python 3.11, https://github.com/kislyuk/argcomplete/issues/481")
+    if sys.version_info[:2] >= (3, 11) and (sys.version_info >= (3, 11, 9) or sys.version_info >= (3, 12, 3)):
+        version = ".".join(str(p) for p in sys.version_info[:3])
+        pytest.skip(
+            f"argcomplete is not compatible with Python {version}, https://github.com/kislyuk/argcomplete/issues/481"
+        )
 
 
 @contextmanager
@@ -151,11 +154,11 @@ def test_enum(parser):
     class EnumType(Enum):
         abc = 1
         xyz = 2
-        abd = 3
+        abz = 3
 
     parser.add_argument("--enum", type=EnumType)
     out, err = complete_line(parser, "tool.py --enum=ab")
-    assert out == "abc\x0babd"
+    assert out == "abc\x0babz"
     assert err == ""
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [n/a] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
