### PR TITLE
Fix parameter resolving falling back to assumptions resolver for optional Union types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ Added
 - Support for ``TypedDict`` (`#457
   <https://github.com/omni-us/jsonargparse/issues/457>`__).
 
+Fixed
+^^^^^
+- Parameter resolving falling back to assumptions resolver for optional
+  ``Union`` types.
+
 
 v4.28.0 (2024-04-17)
 --------------------

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -346,11 +346,14 @@ def is_param_subclass_instance_default(param: ParamData) -> bool:
 
     annotation = get_optional_arg(param.annotation)
     class_types = get_subclass_types(annotation)
-    return (class_types and isinstance(param.default, class_types)) or (
-        is_lambda(param.default)
-        and ActionTypeHint.is_callable_typehint(annotation, all_subtypes=False)
-        and annotation.__args__
-        and ActionTypeHint.is_subclass_typehint(annotation.__args__[-1], all_subtypes=False)
+    return bool(
+        (class_types and isinstance(param.default, class_types))
+        or (
+            is_lambda(param.default)
+            and ActionTypeHint.is_callable_typehint(annotation, all_subtypes=False)
+            and getattr(annotation, "__args__", None)
+            and ActionTypeHint.is_subclass_typehint(annotation.__args__[-1], all_subtypes=False)
+        )
     )
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
