### PR TITLE
Fix nested parameters failing to parse from command line when value includes space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Fixed
 ^^^^^
 - Parameter resolving falling back to assumptions resolver for optional
   ``Union`` types.
+- Nested parameters failing to parse from command line when value includes
+  space.
 
 
 v4.28.0 (2024-04-17)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -265,13 +265,12 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         return namespace, args
 
     def _parse_optional(self, arg_string):
-        if arg_string == self._print_config:
-            arg_string += "="
-        arg_parsed = super()._parse_optional(arg_string)
-        subclass_arg = ActionTypeHint.parse_argv_item(arg_string, arg_parsed)
+        subclass_arg = ActionTypeHint.parse_argv_item(arg_string)
         if subclass_arg:
             return subclass_arg
-        return arg_parsed
+        if arg_string == self._print_config:
+            arg_string += "="
+        return super()._parse_optional(arg_string)
 
     def _parse_common(
         self,

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -160,6 +160,16 @@ allow_default_instance: ContextVar = ContextVar("allow_default_instance", defaul
 sub_defaults: ContextVar = ContextVar("sub_defaults", default=False)
 
 
+def get_parse_optional_num_return() -> int:
+    parser = __import__("argparse").ArgumentParser()
+    parser.add_argument("--test")
+    arg_parsed = parser._parse_optional("--test=x")
+    return len(arg_parsed)
+
+
+parse_optional_num_return = get_parse_optional_num_return()
+
+
 class ActionTypeHint(Action):
     """Action to parse a type hint."""
 
@@ -339,7 +349,7 @@ class ActionTypeHint(Action):
         return result
 
     @staticmethod
-    def parse_argv_item(arg_string, arg_parsed):
+    def parse_argv_item(arg_string):
         parser = subclass_arg_parser.get()
         action = None
         sep = None
@@ -352,7 +362,7 @@ class ActionTypeHint(Action):
 
         typehint = typehint_from_action(action)
         if typehint:
-            if len(arg_parsed) == 4:
+            if parse_optional_num_return == 4:
                 return action, arg_base, sep, explicit_arg
             return action, arg_base, explicit_arg
         return None

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -486,6 +486,12 @@ def test_dict_command_line_set_items(parser):
     assert cfg.dict == {"one": 1, "two": 2}
 
 
+def test_dict_command_line_set_items_with_space(parser):
+    parser.add_argument("--dict", type=dict)
+    cfg = parser.parse_args(["--dict.a=x y"])
+    assert {"a": "x y"} == cfg.dict
+
+
 def test_mapping_nested_without_args(parser):
     parser.add_argument("--map", type=Mapping[str, Union[int, Mapping]])
     assert {"a": 1} == parser.parse_args(['--map={"a": 1}']).map


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
