### PR TITLE
 Support implicit class_path when given a dict or single parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Added
 ^^^^^
 - Support for ``TypedDict`` (`#457
   <https://github.com/omni-us/jsonargparse/issues/457>`__).
+- Directly providing a dict with parameters or a single parameter to a subclass
+  or callable with class return now implicitly tries using the base class as
+  ``class_path`` if not abstract.
 
 Fixed
 ^^^^^

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -2013,6 +2013,16 @@ been imported before parsing. Abstract classes and private classes (module or
 name starting with ``'_'``) are not considered. All the subclasses resolvable by
 its name can be seen in the general help ``python tool.py --help``.
 
+When the base class is not abstract, the ``class_path`` can be omitted, by
+giving directly ``init_args``, for example:
+
+.. code-block:: bash
+
+    python tool.py --calendar.firstweekday 2
+
+would implicitly use ``calendar.Calendar`` as the class path.
+
+
 Default values
 --------------
 

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -313,7 +313,10 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         _ActionPrintConfig.print_config_if_requested(self, cfg)
 
         with parser_context(parent_parser=self):
-            ActionLink.apply_parsing_links(self, cfg)
+            try:
+                ActionLink.apply_parsing_links(self, cfg)
+            except Exception as ex:
+                self.error(str(ex), ex)
 
             if not skip_check and not lenient_check.get():
                 self.check_config(cfg, skip_required=skip_required)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -865,6 +865,11 @@ def adapt_typehints(
                     else:
                         raise ImportError(f"Unexpected import object {val_obj}")
                 if isinstance(val, (dict, Namespace, NestedArg)):
+                    if prev_val is None:
+                        return_type = get_callable_return_type(typehint)
+                        if return_type and not inspect.isabstract(return_type):
+                            with suppress(ValueError):
+                                prev_val = Namespace(class_path=get_import_path(return_type))
                     val = subclass_spec_as_namespace(val, prev_val)
                     if not is_subclass_spec(val):
                         raise ImportError(
@@ -920,6 +925,9 @@ def adapt_typehints(
             return val
 
         val_input = val
+        if prev_val is None and not inspect.isabstract(typehint):
+            with suppress(ValueError):
+                prev_val = Namespace(class_path=get_import_path(typehint))
         val = subclass_spec_as_namespace(val, prev_val)
         if not is_subclass_spec(val):
             raise_unexpected_value(

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from calendar import Calendar, TextCalendar
 from dataclasses import dataclass
+from importlib.util import find_spec
 from typing import Any, Callable, List, Mapping, Optional, Union
 
 import pytest
@@ -51,7 +52,7 @@ def test_on_parse_subcommand_failing_compute_fn(parser, subparser, subtests):
     subcommands.add_subcommand("sub", subparser)
 
     with subtests.test("parse_args"):
-        with pytest.raises(ValueError) as ctx:
+        with pytest.raises(ArgumentError) as ctx:
             parser.parse_args(["sub"])
         ctx.match("Call to compute_fn of link 'to_str.*failed: value is empty")
 
@@ -111,7 +112,10 @@ def test_on_parse_compute_fn_subclass_spec(parser, subtests):
         parser.set_defaults(cal1=None)
         with pytest.raises(ArgumentError) as ctx:
             parser.parse_args(["--cal1.firstweekday=-"])
-        ctx.match('Parser key "cal1"')
+        if find_spec("typeshed_client"):
+            ctx.match('Parser key "cal1"')
+        else:
+            ctx.match("Call to compute_fn of link")
 
 
 class ClassA:

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -754,6 +754,16 @@ def test_callable_args_return_type_class(parser, subtests):
             assert f"{__name__}.{name}" in help_str
 
 
+def test_callable_return_type_class_implicit_class_path(parser):
+    parser.add_argument("--optimizer", type=Callable[[List[float]], Optimizer])
+    cfg = parser.parse_args(['--optimizer={"lr": 0.5}'])
+    assert cfg.optimizer.class_path == f"{__name__}.Optimizer"
+    assert cfg.optimizer.init_args == Namespace(lr=0.5, momentum=0.0)
+    cfg = parser.parse_args(["--optimizer.momentum=0.2"])
+    assert cfg.optimizer.class_path == f"{__name__}.Optimizer"
+    assert cfg.optimizer.init_args == Namespace(lr=0.001, momentum=0.2)
+
+
 def test_callable_multiple_args_return_type_class(parser, subtests):
     parser.add_argument("--optimizer", type=Callable[[List[float], float], Optimizer], default=SGD)
 
@@ -924,7 +934,7 @@ class Model(Module):
         self.activation = activation
 
 
-def test_callable_zero_args_return_type_class(parser):  # , subtests):
+def test_callable_zero_args_return_type_class(parser):
     parser.add_class_arguments(Model, "model")
     cfg = parser.parse_args([])
     assert cfg.model.activation == Namespace(


### PR DESCRIPTION
## What does this PR do?

Directly providing a dict with parameters or a single parameter to a subclass or callable with class return now implicitly tries using the base class as class_path if not abstract.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
