### PR TITLE
Fix: Parsing incorrectly provides file content when type is a union with a subclass, PathLike and string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,12 @@ Added
   (`lightning#13613
   <https://github.com/Lightning-AI/pytorch-lightning/discussions/13613>`__)
 
+Fixed
+^^^^^
+- Parsing incorrectly provides file content when type is a union with a
+  subclass, PathLike and string (`#516
+  <https://github.com/omni-us/jsonargparse/issues/516>`__).
+
 
 v4.29.0 (2024-05-24)
 --------------------

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -198,7 +198,7 @@ class ActionTypeHint(Action):
                     subtypes = tuple(t for t, s in zip(typehint.__args__, subtype_supported) if s)
                     typehint = Union[subtypes]  # type: ignore[assignment]
             self._typehint = typehint
-            self._enable_path = False if is_optional(typehint, Path) else enable_path
+            self._enable_path = False if is_pathlike(typehint) else enable_path
         elif "_typehint" not in kwargs:
             raise ValueError("Expected typehint keyword argument.")
         else:
@@ -645,6 +645,12 @@ class ActionTypeHint(Action):
                 msg = "value not yet valid, "
             msg += "expected type " + type_to_str(self._typehint)
             return argcomplete_warn_redraw_prompt(prefix, msg)
+
+
+def is_pathlike(typehint) -> bool:
+    if get_typehint_origin(typehint) == Union:
+        return any(is_pathlike(t) for t in typehint.__args__)
+    return is_subclass(typehint, os.PathLike)
 
 
 def raise_unexpected_value(message: str, val: Any = inspect._empty, exception: Optional[Exception] = None) -> NoReturn:


### PR DESCRIPTION
## What does this PR do?

Fixes #516

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
