### PR TITLE
Fix --print_config failing in some cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Fixed
 - Parsing incorrectly provides file content when type is a union with a
   subclass, PathLike and string (`#516
   <https://github.com/omni-us/jsonargparse/issues/516>`__).
+- ``--print_config`` failing in some cases (`#517
+  <https://github.com/omni-us/jsonargparse/issues/517>`__).
 
 
 v4.29.0 (2024-05-24)

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -122,7 +122,7 @@ def get_unaliased_type(cls):
 def is_dataclass_like(cls) -> bool:
     if is_generic_class(cls):
         return is_dataclass_like(cls.__origin__)
-    if not inspect.isclass(cls):
+    if not inspect.isclass(cls) or cls is object:
         return False
     if is_final_class(cls):
         return True

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -108,7 +108,7 @@ def is_classmethod(parent, component) -> bool:
 
 
 def is_lambda(value: Any) -> bool:
-    return callable(value) and value.__name__ == "<lambda>"
+    return callable(value) and getattr(value, "__name__", "") == "<lambda>"
 
 
 def ast_str(node):


### PR DESCRIPTION
## What does this PR do?

Noticed from the reproduction code in #517 that --print_config can fail in some cases. This fixes it.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
