### PR TITLE
Initial scriptconfig support

### DIFF
--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -44,6 +44,22 @@ class ParamData:
     component: Optional[Union[Callable, Type, Tuple]] = None
     parent: Optional[Union[Type, Tuple]] = None
     origin: Optional[Union[str, Tuple]] = None
+    short_aliases: Optional[List[str]] = None
+    long_aliases: Optional[List[str]] = None
+
+    def _resolve_args_and_dest(self, is_required=False, as_positional=False, nested_key: Optional[str] = None):
+        name = self.name
+        dest = (nested_key + "." if nested_key else "") + name
+        if is_required and as_positional:
+            args = [dest]
+        else:
+            long_names = [name] + list((self.long_aliases or []))
+            short_names = list(self.short_aliases or [])
+            nest_prefix = nested_key + "." if nested_key else ""
+            short_option_strings = ["-" + nest_prefix + n for n in short_names]
+            long_option_strings = ["--" + nest_prefix + n for n in long_names]
+            args = short_option_strings + long_option_strings
+        return args, dest
 
 
 ParamList = List[ParamData]


### PR DESCRIPTION


## What does this PR do?

This PR is an initial attempt at https://github.com/omni-us/jsonargparse/issues/244 

This allows a user to define a scriptconfig object that gives them fine-grained control over the arguments and metadata on the CLI, without requiring the variables to be typed more than once. In other words, the signature of a function is maintained in a class, and it is assumed that the keyword arguments given to that class will be used to create an instance of the scriptconfig object.

Here is what the MWE looks like:

```python
import scriptconfig as scfg


class MyClassConfig(scfg.DataConfig):
    key1 = scfg.Value(1, alias=['key_one'], help='description1')
    key2 = scfg.Value(None, type=str, help='description1')
    key3 = scfg.Value(False, isflag=True, help='description1')
    key4 = 123
    key5 = '123'


class MyClass:
    __scriptconfig__ = MyClassConfig

    def __init__(self, regular_param1, **kwargs):
        self.regular_param1 = regular_param1
        self.config = MyClassConfig(**kwargs)


def main():
    import jsonargparse
    import shlex
    import ubelt as ub
    import rich
    from rich.markup import escape
    parser = jsonargparse.ArgumentParser()
    parser.add_class_arguments(MyClass, nested_key='my_class', fail_untyped=False, sub_configs=True)
    parser.add_argument('--foo', default='bar')
    parser.add_argument('-b', '--baz', '--buzz', default='bar')
    print('Parse Args')
    cases = [
        '',
        '--my_class.key1 123',
        '--my_class.key_one 123ab',
        '--my_class.key4 strings-are-ok',
    ]
    for case_idx, case in enumerate(cases):
        print('--- Case {case_idx} ---')
        print(f'case={case}')
        args = shlex.split(case)
        config = parser.parse_args(args)
        instances = parser.instantiate_classes(config)

        my_class = instances.my_class
        rich.print(f'config = {escape(ub.urepr(config, nl=2))}')
        rich.print(f'my_class.config = {escape(ub.urepr(my_class.config, nl=2))}')
        print('---')


if __name__ == '__main__':
    """
    CommandLine:
        cd ~/code/geowatch/dev/mwe/
        python jsonargparse_scriptconfig_integration_test.py
    """
    main()
```

You'll note that it looks similar to dataclass / pydantic / attrs object. However,  a major difference is that it doesn't rely on type annotations to store metadata. It uses a special "Value" class, which can be augmented with things like help, aliases, and other information useful to building both a CLI and a function / class signature.

The main scriptconfig page is here for more information: https://gitlab.kitware.com/utils/scriptconfig

I've been using a monkey-patched version of jsonargparse that allows me to work with scriptconfig objects for over a year now, and in late 2023 there was some change to jsonargparse that broke me. This force me to pin jsonargparse and pytorch_lightning to older versions, and I've finally had time to look into it. However, I'd really really really like is there was something codified into jsonargparse that would either directly support scriptconfig or expose some way for users to do custom things when running `add_class_arguments` based on a property in the class itself (which will let it integrate with lightning much easier). I don't particularly care if scriptconfig itself is supported, what I need is something that won't get deprecated or refactored that I can hook into.

So far this PR just adds basic support for scriptconfig itself. This involves some extra logic in `_add_scriptconfig_arguments`, and in order to support the alias feature of scriptconfig, I updated `ParamData` so it is now equipped with a `short_aliases` and a `long_aliases` attribute. I've also added a method to it so it can construct the args that will ultimately be passed to argparse. This makes modifications to `_add_signature_parameter` a bit cleaner, and also sets the stage to allow other argument sources to specify aliases.



## Before submitting

- [ ] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ ] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [ ] Did you verify that new and existing **tests pass locally**?
- [ ] Did you make sure that all changes preserve **backward compatibility**?
- [ ] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

WRT to this checklist, I don't want to invest too much time into this before having a discussion with the authors.

I'm looking for feedback on the level of support the maintainers would be willing to provide for something like this. I think the simple thing to do would be to "add scriptconfig support" and be done with it, in which case I could clean up the existing code. The alternative is to allow allow classes to have some attribute (e.g. `__customize_signature__`) that lets the user return a list of additional `ParamData` objects that should be recognized by the CLI. However, that involves making `ParamData` a public class, so that has its own set of tradeoffs. 
