### PR TITLE
Fix: dump failing when a link target requires serialization and skip_link_targets=False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,12 @@ Added
 - Support for ``MappingProxyType`` as a type and as default for mapping types
   (`#540 <https://github.com/omni-us/jsonargparse/pull/540>`__).
 
+Fixed
+^^^^^
+- ``dump`` failing when a link target requires serialization and
+  ``skip_link_targets=False`` (`#542
+  <https://github.com/omni-us/jsonargparse/pull/542>`__).
+
 
 v4.31.0 (2024-06-27)
 --------------------

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -754,7 +754,9 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
                 cfg.pop(action_dest, None)
                 for key, subparser in action.choices.items():
                     self._dump_cleanup_actions(cfg, subparser._actions, dump_kwargs, prefix=prefix + key + ".")
-            elif isinstance(action, ActionTypeHint):
+            elif isinstance(action, ActionLink):
+                action = action.target[1]
+            if isinstance(action, ActionTypeHint):
                 value = cfg.get(action_dest)
                 if value is not None:
                     with parser_context(parent_parser=self):

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -467,6 +467,16 @@ def test_on_parse_nested_callable(parser):
     assert cfg.model.init_args.optimizer.init_args == Namespace(lr=0.01)
 
 
+def test_on_parse_type_skip_link_targets_dump(parser):
+    parser.add_argument("--t1", type=type)
+    parser.add_argument("--t2", type=type)
+    parser.link_arguments("t1", "t2")
+
+    cfg = parser.parse_args([f"--t1={__name__}.Model"])
+    dump = yaml.safe_load(parser.dump(cfg, skip_link_targets=False))
+    assert dump["t2"] == f"{__name__}.Model"
+
+
 # tests for links applied on instantiate
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
