### PR TITLE
New function get_loader to get the current loader for a given parser mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Added
 ^^^^^
 - Support for ``MappingProxyType`` as a type and as default for mapping types
   (`#540 <https://github.com/omni-us/jsonargparse/pull/540>`__).
+- New function ``get_loader`` to get the current loader for a given parser mode
+  (`#479 comment
+  <https://github.com/omni-us/jsonargparse/issues/479#issuecomment-2022596544>`__,
+  `#536 comment
+  <https://github.com/omni-us/jsonargparse/issues/536#issuecomment-2186961644>`__).
 
 Fixed
 ^^^^^

--- a/jsonargparse/_loaders_dumpers.py
+++ b/jsonargparse/_loaders_dumpers.py
@@ -11,6 +11,7 @@ from ._optionals import import_jsonnet, omegaconf_support
 from ._type_checking import ArgumentParser
 
 __all__ = [
+    "get_loader",
     "set_loader",
     "set_dumper",
 ]
@@ -200,6 +201,11 @@ def set_loader(mode: str, loader_fn: Callable[[str], Any], exceptions: Tuple[Typ
     """
     loaders[mode] = loader_fn
     loader_exceptions[mode] = exceptions
+
+
+def get_loader(mode: str):
+    """Returns the current loader function for a given mode."""
+    return loaders[mode]
 
 
 def set_dumper(format_name: str, dumper_fn: Callable[[Any], str]):

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from jsonargparse import ArgumentParser, set_dumper, set_loader
+from jsonargparse import ArgumentParser, get_loader, set_dumper, set_loader
 from jsonargparse._common import parser_context
 from jsonargparse._loaders_dumpers import load_value, loaders, yaml_dump
 from jsonargparse._optionals import omegaconf_support
@@ -85,6 +85,12 @@ def test_parser_mode_omegaconf_interpolation_in_subcommands(parser, subparser):
 
 def test_invalid_parser_mode():
     pytest.raises(ValueError, lambda: ArgumentParser(parser_mode="invalid"))
+
+
+def test_get_loader():
+    from jsonargparse._loaders_dumpers import jsonnet_load
+
+    assert jsonnet_load is get_loader("jsonnet")
 
 
 def test_set_loader_parser_mode_subparsers(parser, subparser):


### PR DESCRIPTION
## What does this PR do?

Addresses https://github.com/omni-us/jsonargparse/issues/479#issuecomment-2022596544 and https://github.com/omni-us/jsonargparse/issues/536#issuecomment-2186961644

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
