### PR TITLE
Fix default_config_files making parse fail for subcommands and nested subclass types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Fixed
 - ``dump`` failing when a link target requires serialization and
   ``skip_link_targets=False`` (`#542
   <https://github.com/omni-us/jsonargparse/pull/542>`__).
+- ``default_config_files`` making parse fail for subcommands and nested subclass
+  types (`lightning-forums#5963
+  <https://lightning.ai/forums/t/problem-lightningcli-with-default-config-files/5963>`__).
 - Import path of inherited classmethod not resolving correctly (`lightning#19863
   comment
   <https://github.com/Lightning-AI/pytorch-lightning/discussions/19863#discussioncomment-10010226>`__).

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -580,12 +580,12 @@ parse_kwargs: ContextVar = ContextVar("parse_kwargs", default={})
 @contextmanager
 def parent_parsers_context(key, parser):
     prev = parent_parsers.get()
-    curr = prev + [(key, parser)]
-    t = parent_parsers.set(curr)
+    curr = [] if parser is None else prev + [(key, parser)]
+    token = parent_parsers.set(curr)
     try:
         yield
     finally:
-        parent_parsers.reset(t)
+        parent_parsers.reset(token)
 
 
 class _ActionSubCommands(_SubParsersAction):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -39,6 +39,7 @@ from ._actions import (
     _find_action,
     _find_parent_action,
     _is_action_value_list,
+    parent_parsers_context,
     remove_actions,
 )
 from ._common import (
@@ -453,7 +454,7 @@ class ActionTypeHint(Action):
                 or (isinstance(v, dict) and any(is_subclass_spec(e) for e in v.values()))
             )
 
-        with ActionTypeHint.sub_defaults_context():
+        with ActionTypeHint.sub_defaults_context(), parent_parsers_context(None, None):
             parser._apply_actions(cfg, skip_fn=skip_sub_defaults_apply)
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

Fixes https://lightning.ai/forums/t/problem-lightningcli-with-default-config-files/5963

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
