### PR TITLE
Fix dict types not correctly forwarding previous nested values when parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ v4.32.1 (2024-08-??)
 Fixed
 ^^^^^
 - ``dict`` types not correctly forwarding previous nested values when parsing
-  (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  (`#559 <https://github.com/omni-us/jsonargparse/pull/559>`__).
 
 
 v4.32.0 (2024-07-19)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.32.1 (2024-08-??)
+--------------------
+
+Fixed
+^^^^^
+- ``dict`` types not correctly forwarding previous nested values when parsing
+  (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
+
 v4.32.0 (2024-07-19)
 --------------------
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -904,7 +904,12 @@ def adapt_typehints(
                         for t in sub_add_kwargs["linked_targets"]
                     }
                 else:
-                    kwargs = adapt_kwargs
+                    kwargs = adapt_kwargs.copy()
+                if kwargs.get("prev_val"):
+                    if isinstance(kwargs["prev_val"], dict):
+                        kwargs["prev_val"] = kwargs["prev_val"].get(k)
+                    else:
+                        kwargs["prev_val"] = None
                 val[k] = adapt_typehints(v, subtypehints[1], **kwargs)
         if get_import_path(typehint.__class__) == "typing._TypedDictMeta":
             if typehint.__total__:


### PR DESCRIPTION
## What does this PR do?

Fixes #555

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
