### PR TITLE
Fix inference of required keys in TypedDicts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ v4.33.0 (2024-09-??)
 Added
 ^^^^^
 - Support for Python 3.13.
+- Support for `NotRequired` and `Required` annotations for `TypedDict` keys (`#571
+  <https://github.com/omni-us/jsonargparse/pull/571>`__)
 
 Fixed
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,6 @@ Fixed
 ^^^^^
 - Callable type with subclass return not showing the ``--*.help`` option (`#567
   <https://github.com/omni-us/jsonargparse/pull/567>`__).
-- Inference of required and missing `TypedDict` keys (`#571
-  <https://github.com/omni-us/jsonargparse/pull/571>`__)
 
 
 v4.32.1 (2024-08-23)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Fixed
 ^^^^^
 - Callable type with subclass return not showing the ``--*.help`` option (`#567
   <https://github.com/omni-us/jsonargparse/pull/567>`__).
+- Inference of required and missing `TypedDict` keys (`#571
+  <https://github.com/omni-us/jsonargparse/pull/571>`__)
 
 
 v4.32.1 (2024-08-23)

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -401,8 +401,10 @@ Some notes about this support are:
   :ref:`parsing-paths` and :ref:`parsing-urls`.
 
 - ``Dict``, ``Mapping``, ``MutableMapping``, ``MappingProxyType``,
-  ``OrderedDict`` and ``TypedDict`` are supported but only with ``str`` or
-  ``int`` keys. For more details see :ref:`dict-items`.
+  ``OrderedDict``, and ``TypedDict`` are supported but only with ``str`` or
+  ``int`` keys. ``Required`` and ``NotRequired`` are also supported for
+  fine-grained specification of required/optional ``TypedDict`` keys.
+  For more details see :ref:`dict-items`.
 
 - ``Tuple``, ``Set`` and ``MutableSet`` are supported even though they can't be
   represented in json distinguishable from a list. Each ``Tuple`` element

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -925,6 +925,16 @@ def adapt_typehints(
         elif typehint_origin is OrderedDict:
             val = dict(val) if serialize else OrderedDict(val)
 
+    # NotRequired
+    elif typehint_origin in not_required_types:
+        assert len(subtypehints) == 1, "NotRequired requires a single type argument"
+        val = adapt_typehints(val, subtypehints[0], **adapt_kwargs)
+
+    # Required
+    elif typehint_origin in required_types:
+        assert len(subtypehints) == 1, "Required requires a single type argument"
+        val = adapt_typehints(val, subtypehints[0], **adapt_kwargs)
+
     # Callable
     elif typehint_origin in callable_origin_types or typehint in callable_origin_types:
         if serialize:

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -185,6 +185,7 @@ _capture_typing_extension_shadows("NotRequired", root_types, not_required_types)
 
 required_types = {Required}
 _capture_typing_extension_shadows("Required", root_types, required_types)
+not_required_required_types = not_required_types.union(required_types)
 
 typed_dict_types = {TypedDict}
 _capture_typing_extension_shadows("TypedDict", typed_dict_types)
@@ -939,14 +940,9 @@ def adapt_typehints(
         elif typehint_origin is OrderedDict:
             val = dict(val) if serialize else OrderedDict(val)
 
-    # NotRequired
-    elif typehint_origin in not_required_types:
-        assert len(subtypehints) == 1, "NotRequired requires a single type argument"
-        val = adapt_typehints(val, subtypehints[0], **adapt_kwargs)
-
-    # Required
-    elif typehint_origin in required_types:
-        assert len(subtypehints) == 1, "Required requires a single type argument"
+    # TypedDict NotRequired and Required
+    elif typehint_origin in not_required_required_types:
+        assert len(subtypehints) == 1, "(Not)Required requires a single type argument"
         val = adapt_typehints(val, subtypehints[0], **adapt_kwargs)
 
     # Callable

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -275,6 +275,8 @@ def get_typehint_origin(typehint):
             return Union
         if typehint_class == "typing._TypedDictMeta":
             return dict
+        if typehint_class == "typing_extensions._TypedDictMeta":
+            return dict
     return getattr(typehint, "__origin__", None)
 
 

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -273,9 +273,7 @@ def get_typehint_origin(typehint):
         typehint_class = get_import_path(typehint.__class__)
         if typehint_class == "types.UnionType":
             return Union
-        if typehint_class == "typing._TypedDictMeta":
-            return dict
-        if typehint_class == "typing_extensions._TypedDictMeta":
+        if typehint_class in {"typing._TypedDictMeta", "typing_extensions._TypedDictMeta"}:
             return dict
     return getattr(typehint, "__origin__", None)
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -24,10 +24,6 @@ from typing import (
     Type,
     Union,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-
 from unittest import mock
 from warnings import catch_warnings
 
@@ -40,6 +36,7 @@ from jsonargparse._typehints import (
     Literal,
     NotRequired,
     Required,
+    TypedDict,
     get_all_subclass_paths,
     get_subclass_types,
     is_optional,
@@ -504,7 +501,7 @@ def test_mapping_nested_without_args(parser):
     assert {"b": {"c": 2}} == parser.parse_args(['--map={"b": {"c": 2}}']).map
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="TypedDict introduced in python 3.8")
+@pytest.mark.skipif(not TypedDict, reason="TypedDict introduced in python 3.8 or backported in typing_extensions")
 def test_typeddict_without_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {}))
     assert {} == parser.parse_args(["--typeddict={}"])["typeddict"]
@@ -516,7 +513,7 @@ def test_typeddict_without_arg(parser):
     ctx.match("Expected a <class 'dict'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="TypedDict introduced in python 3.8")
+@pytest.mark.skipif(not TypedDict, reason="TypedDict introduced in python 3.8 or backported in typing_extensions")
 def test_typeddict_with_args(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
@@ -535,7 +532,7 @@ def test_typeddict_with_args(parser):
     ctx.match("Expected a <class 'dict'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="TypedDict introduced in python 3.8")
+@pytest.mark.skipif(not TypedDict, reason="TypedDict introduced in python 3.8 or backported in typing_extensions")
 def test_typeddict_with_args_ntotal(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int}, total=False))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -518,7 +518,7 @@ def test_typeddict_without_arg(parser):
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="TypedDict introduced in python 3.8")
 def test_typeddict_with_args(parser):
-    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
+    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(['--typeddict={"a":1, "b":2}'])
@@ -551,7 +551,7 @@ def test_typeddict_with_args_ntotal(parser):
     ctx.match("Expected a <class 'dict'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="TypedDict introduced in python 3.11")
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="NotRequired introduced in python 3.11")
 def test_typeddict_with_not_required_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
@@ -573,7 +573,7 @@ def test_typeddict_with_not_required_arg(parser):
     ctx.match("Expected a <class 'int'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="TypedDict introduced in python 3.11")
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Required introduced in python 3.11")
 def test_typeddict_with_required_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": Required[int], "b": int}, total=False))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -27,8 +27,6 @@ from typing import (
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
-if sys.version_info >= (3, 11):
-    from typing import NotRequired, Required
 
 from unittest import mock
 from warnings import catch_warnings
@@ -40,6 +38,8 @@ from jsonargparse import ArgumentError, Namespace, lazy_instance
 from jsonargparse._typehints import (
     ActionTypeHint,
     Literal,
+    NotRequired,
+    Required,
     get_all_subclass_paths,
     get_subclass_types,
     is_optional,
@@ -551,12 +551,12 @@ def test_typeddict_with_args_ntotal(parser):
     ctx.match("Expected a <class 'dict'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="NotRequired introduced in python 3.11")
+@pytest.mark.skipif(not NotRequired, reason="NotRequired introduced in python 3.11 or backported in typing_extensions")
 def test_not_required_support(parser):
     assert ActionTypeHint.is_supported_typehint(NotRequired[Any])
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="NotRequired introduced in python 3.11")
+@pytest.mark.skipif(not NotRequired, reason="NotRequired introduced in python 3.11 or backported in typing_extensions")
 def test_typeddict_with_not_required_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
@@ -578,12 +578,12 @@ def test_typeddict_with_not_required_arg(parser):
     ctx.match("Expected a <class 'int'>")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Required introduced in python 3.11")
+@pytest.mark.skipif(not Required, reason="Required introduced in python 3.11 or backported in typing_extensions")
 def test_required_support(parser):
     assert ActionTypeHint.is_supported_typehint(Required[Any])
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Required introduced in python 3.11")
+@pytest.mark.skipif(not Required, reason="Required introduced in python 3.11 or backported in typing_extensions")
 def test_typeddict_with_required_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": Required[int], "b": int}, total=False))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -27,6 +27,9 @@ from typing import (
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required
+
 from unittest import mock
 from warnings import catch_warnings
 
@@ -515,7 +518,7 @@ def test_typeddict_without_arg(parser):
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="TypedDict introduced in python 3.8")
 def test_typeddict_with_args(parser):
-    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int}))
+    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(['--typeddict={"a":1, "b":2}'])
@@ -546,6 +549,50 @@ def test_typeddict_with_args_ntotal(parser):
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(["--typeddict=1"])
     ctx.match("Expected a <class 'dict'>")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="TypedDict introduced in python 3.11")
+def test_typeddict_with_not_required_arg(parser):
+    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
+    assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
+    assert {"a": 1, "b": 2} == parser.parse_args(["--typeddict={'a': 1, 'b': 2}"])["typeddict"]
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":1, "b":2, "c": 3}'])
+    ctx.match("Unexpected keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"b":2}'])
+    ctx.match("Missing required keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(["--typeddict={}"])
+    ctx.match("Missing required keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":"x"}'])
+    ctx.match("Expected a <class 'int'>")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":1, "b":"x"}'])
+    ctx.match("Expected a <class 'int'>")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="TypedDict introduced in python 3.11")
+def test_typeddict_with_required_arg(parser):
+    parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": Required[int], "b": int}, total=False))
+    assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
+    assert {"a": 1, "b": 2} == parser.parse_args(["--typeddict={'a': 1, 'b': 2}"])["typeddict"]
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":1, "b":2, "c": 3}'])
+    ctx.match("Unexpected keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"b":2}'])
+    ctx.match("Missing required keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(["--typeddict={}"])
+    ctx.match("Missing required keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":"x"}'])
+    ctx.match("Expected a <class 'int'>")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--typeddict={"a":1, "b":"x"}'])
+    ctx.match("Expected a <class 'int'>")
 
 
 def test_mapping_proxy_type(parser):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -552,6 +552,11 @@ def test_typeddict_with_args_ntotal(parser):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="NotRequired introduced in python 3.11")
+def test_not_required_support(parser):
+    assert ActionTypeHint.is_supported_typehint(NotRequired[Any])
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="NotRequired introduced in python 3.11")
 def test_typeddict_with_not_required_arg(parser):
     parser.add_argument("--typeddict", type=TypedDict("MyDict", {"a": int, "b": NotRequired[int]}))
     assert {"a": 1} == parser.parse_args(["--typeddict={'a': 1}"])["typeddict"]
@@ -571,6 +576,11 @@ def test_typeddict_with_not_required_arg(parser):
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(['--typeddict={"a":1, "b":"x"}'])
     ctx.match("Expected a <class 'int'>")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Required introduced in python 3.11")
+def test_required_support(parser):
+    assert ActionTypeHint.is_supported_typehint(Required[Any])
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Required introduced in python 3.11")


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->

This PR fixes inference of required and missing keys in `TypedDict`s.

Closes #570 

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
