### PR TITLE
Fix tests inside of docker

### DIFF
--- a/jsonargparse_tests/conftest.py
+++ b/jsonargparse_tests/conftest.py
@@ -70,6 +70,11 @@ skip_if_responses_unavailable = pytest.mark.skipif(
     reason="responses package is required",
 )
 
+skip_if_running_as_root = pytest.mark.skipif(
+    is_posix and os.geteuid() == 0,
+    reason="User is root, permission tests will not work",
+)
+
 if responses_available:
     import responses
 

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -39,6 +39,7 @@ from jsonargparse_tests.conftest import (
     skip_if_fsspec_unavailable,
     skip_if_not_posix,
     skip_if_responses_unavailable,
+    skip_if_running_as_root,
 )
 
 
@@ -329,6 +330,7 @@ def test_parse_path_defaults(parser, tmp_cwd):
 
 
 @skip_if_not_posix
+@skip_if_running_as_root
 def test_parse_path_file_not_readable(parser, tmp_cwd):
     config_path = Path("config.json")
     config_path.touch()
@@ -792,6 +794,7 @@ def test_default_config_file_invalid_value(parser, tmp_cwd):
 
 
 @skip_if_not_posix
+@skip_if_running_as_root
 def test_default_config_file_unreadable(parser, tmp_cwd):
     default_config_file = Path("defaults.yaml")
     default_config_file.write_text("op1: from yaml\n")

--- a/jsonargparse_tests/test_util.py
+++ b/jsonargparse_tests/test_util.py
@@ -47,6 +47,7 @@ from jsonargparse_tests.conftest import (
     skip_if_fsspec_unavailable,
     skip_if_requests_unavailable,
     skip_if_responses_unavailable,
+    skip_if_running_as_root,
 )
 
 if responses_available:
@@ -136,6 +137,7 @@ def test_path_equality_operator(paths):
     assert Path("123", "fc") != 123
 
 
+@skip_if_running_as_root
 def test_path_file_access_mode(paths):
     Path(paths.file_rw, "frw")
     Path(paths.file_r, "fr")
@@ -150,6 +152,7 @@ def test_path_file_access_mode(paths):
     pytest.raises(TypeError, lambda: Path("file_ne", "fr"))
 
 
+@skip_if_running_as_root
 def test_path_dir_access_mode(paths):
     Path(paths.dir_rwx, "drwx")
     Path(paths.dir_rx, "drx")
@@ -166,6 +169,7 @@ def test_path_get_content(paths):
     assert "file contents" == Path(f"file://{paths.tmp_path}/{paths.file_r}", "ur").get_content()
 
 
+@skip_if_running_as_root
 def test_path_create_mode(paths):
     Path(paths.file_rw, "fcrw")
     Path(paths.tmp_path / "file_c", "fc")


### PR DESCRIPTION
I've run into a tricky issue when running tests locally inside of a docker environment. Tests that involved changing permissions to make a file unreadable were failing when I ran them inside of docker, but they worked on my host system. After a bit of thinking I realized this was because the default user in docker is root, which means files can be read even if they are unreadable according to the permissions.

To address this, I made two changes:
* In test_core, I check if I can still read the file after it is forced to be unreadable. If it can be, then we can assume we are in some special circumstance, and we should skip the test.

* In test_util, it looks like there is a custom path object, so I fell back to just checking if `os.geteuid() == 0`, which should only be true on linux for the root user. In this case I skip the test.

Because this is only a test change, I'm not sure if you want a changelog entry. 