### PR TITLE
Fix issue #590: Behavior change in `argparse._parse_optional` breaks the parse of optional arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.33.2 (2024-10-??)
+--------------------
+
+Fixed
+^^^^^
+- Fix `parse_argv_item` to address the behavior change in `argparse` since Python 3.12.7 (`#591 <https://github.com/omni-us/jsonargparse/pull/591>`__).
+
+
 v4.33.1 (2024-09-26)
 --------------------
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -396,6 +396,8 @@ class ActionTypeHint(Action):
         if typehint:
             if parse_optional_num_return == 4:
                 return action, arg_base, sep, explicit_arg
+            elif parse_optional_num_return == 1:
+                return [(action, arg_base, sep, explicit_arg)]
             return action, arg_base, explicit_arg
         return None
 

--- a/jsonargparse_tests/test_argcomplete.py
+++ b/jsonargparse_tests/test_argcomplete.py
@@ -28,6 +28,12 @@ def skip_if_argcomplete_unavailable():
         pytest.skip("argcomplete package is required")
 
 
+@pytest.fixture(autouse=True)
+def temporal_skip_if_ge_py3127():
+    if sys.version_info[:3] >= (3, 12, 7):
+        pytest.skip("currently failing on python>=3.12.7 due to argparse breaking change")
+
+
 @contextmanager
 def mock_fdopen():
     err = StringIO()


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?


In Python 3.13 and 3.12.7, the behavior of `_parse_optional` has changed to return a list of tuples: https://github.com/python/cpython/pull/124631
This change would break the argument parser of this library.
For example, the existing unit test failed, resulting in:
```
FAILED jsonargparse_tests/test_dataclass_like.py::test_optional_dataclass_single_param_change - argparse.ArgumentError: cannot unpack non-iterable ActionTypeHint object
``` 

This PR will detect this behavior and return the proper format accordingly.
This PR resolves issue #590.



## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [ ] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
