### PR TITLE
fix: callable protocols

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+v4.33.4 (2024-10-??)
+--------------------
+
+Fixed
+^^^^^
+- Fixes callable protocols inheritance.
+
 
 v4.33.3 (2024-10-??)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.33.3 (2024-10-09)
+v4.33.3 (2024-10-??)
 --------------------
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.33.2 (2024-10-09)
+--------------------
+
+Fixed
+^^^^^
+- Empty tuples are now parsed correctly instead of raising an error.
+  (`#592 <https://github.com/omni-us/jsonargparse/pull/592`__).
+
+
+
 v4.33.1 (2024-09-26)
 --------------------
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1076,6 +1076,7 @@ def adapt_typehints(
 
 
 def implements_protocol(value, protocol) -> bool:
+    allowed_dunder_methods = {"__call__"}
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
@@ -1083,7 +1084,7 @@ def implements_protocol(value, protocol) -> bool:
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):
-        if name.startswith("_"):
+        if name.startswith("_") and name not in allowed_dunder_methods:
             continue
         if not hasattr(value, name):
             return False

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -847,8 +847,6 @@ def adapt_typehints(
             for n, v in enumerate(val):
                 subtypehint = subtypehints[0 if is_ellipsis or not is_tuple else n]
                 val[n] = adapt_typehints(v, subtypehint, **adapt_kwargs)
-            if is_tuple and len(val) == 0:
-                val = ()
         if not serialize:
             val = tuple(val) if typehint_origin in {Tuple, tuple} else set(val)
 

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -848,7 +848,7 @@ def adapt_typehints(
                 subtypehint = subtypehints[0 if is_ellipsis or not is_tuple else n]
                 val[n] = adapt_typehints(v, subtypehint, **adapt_kwargs)
             if is_tuple and len(val) == 0:
-                raise_unexpected_value("Expected a non-empty tuple", val)
+                val = ()
         if not serialize:
             val = tuple(val) if typehint_origin in {Tuple, tuple} else set(val)
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -286,7 +286,7 @@ def test_tuple_ellipsis(parser):
     parser.add_argument("--tuple", type=Tuple[float, ...])
     assert (1.2,) == parser.parse_args(["--tuple=[1.2]"]).tuple
     assert (1.2, 3.4) == parser.parse_args(["--tuple=[1.2, 3.4]"]).tuple
-    pytest.raises(ArgumentError, lambda: parser.parse_args(["--tuple=[]"]))
+    assert () == parser.parse_args(["--tuple=[]"]).tuple
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--tuple=[2, "a"]']))
 
 


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Fixes callable protocol inheritance by making an exception for the `__call__` method as an allowed private method for checking the signatures of inherited classes.

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ ] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
