### PR TITLE
Fix/callable protocols 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,13 +11,6 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
-v4.34.1 (2024-10-??)
---------------------
-
-Fixed
-^^^^^
-- Fix callable protocol inheritance.
-
 
 v4.34.0 (2024-10-??)
 --------------------
@@ -40,6 +33,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/608>`__).
 - Failure when resolving forward references from dataclass parameter types
   (`#611 <https://github.com/omni-us/jsonargparse/pull/611>`__).
+- Fix callable protocol inheritance.
+  (`#599 <https://github.com/omni-us/jsonargparse/pull/599>`__).
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+v4.34.1 (2024-10-??)
+--------------------
+
+Fixed
+^^^^^
+- Fix callable protocol inheritance.
+
 
 v4.34.0 (2024-10-??)
 --------------------

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1101,6 +1101,7 @@ def adapt_typehints(
 
 
 def implements_protocol(value, protocol) -> bool:
+    allowed_dunder_methods = {"__call__"}
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
@@ -1108,7 +1109,7 @@ def implements_protocol(value, protocol) -> bool:
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):
-        if name.startswith("_"):
+        if name.startswith("_") and name not in allowed_dunder_methods::
             continue
         if not hasattr(value, name):
             return False

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1087,8 +1087,23 @@ def adapt_typehints(
     return val
 
 
+protocol_irrelevant_dunder_methods = {
+    "__init__",
+    "__new__",
+    "__del__",
+    "__getattr__",
+    "__getattribute__",
+    "__setattr__",
+    "__delattr__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__getstate__",
+    "__setstate__",
+    "__subclasshook__",
+}
+
+
 def implements_protocol(value, protocol) -> bool:
-    allowed_dunder_methods = {"__call__"}
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
@@ -1096,7 +1111,8 @@ def implements_protocol(value, protocol) -> bool:
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):
-        if name.startswith("_") and name not in allowed_dunder_methods:
+        is_dunder = name.startswith("__") and name.endswith("__")
+        if (not is_dunder and name.startswith("_")) or (is_dunder and name in protocol_irrelevant_dunder_methods):
             continue
         if not hasattr(value, name):
             return False

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1105,7 +1105,7 @@ def implements_protocol(value, protocol) -> bool:
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
-    if not inspect.isclass(value):
+    if not inspect.isclass(value): # Should we check if callables implement protocols?
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1105,7 +1105,7 @@ def implements_protocol(value, protocol) -> bool:
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
-    if not inspect.isclass(value): # Should we check if callables implement protocols?
+    if not inspect.isclass(value):  # Should we check if callables implement protocols?
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1107,7 +1107,7 @@ def implements_protocol(value, protocol) -> bool:
     from jsonargparse._parameter_resolvers import get_signature_parameters
     from jsonargparse._postponed_annotations import get_return_type
 
-    if not inspect.isclass(value):  # Should we check if callables implement protocols?
+    if not inspect.isclass(value) or value is object:
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1109,7 +1109,7 @@ def implements_protocol(value, protocol) -> bool:
         return False
     members = 0
     for name, _ in inspect.getmembers(protocol, predicate=inspect.isfunction):
-        if name.startswith("_") and name not in allowed_dunder_methods::
+        if name.startswith("_") and name not in allowed_dunder_methods:
             continue
         if not hasattr(value, name):
             return False

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1823,7 +1823,3 @@ def test_subclass_error_indentation_in_union_invalid_value(parser):
     ).strip()
     expected = textwrap.indent(expected, "  ")
     assert "\n".join(expected.splitlines()) in "\n".join(err.splitlines())
-
-
-# if __name__ == "__main__":
-#     test_implements_protocol(True, ImplementsInterface)

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1515,6 +1515,7 @@ class ImplementsCallableInterface1:
         return items
 
 
+# TODO: make functions that implement protocol be checked correctly
 def implements_callable_interface2(items: List[float]) -> List[float]:
     return items
 
@@ -1534,6 +1535,7 @@ class NotImplementsCallableInterface3:
         return
 
 
+# TODO: make functions that implement protocol be checked correctly
 def not_implements_callable_interface4(items: str) -> List[float]:
     return []
 
@@ -1543,7 +1545,10 @@ def not_implements_callable_interface4(items: str) -> List[float]:
     [
         (True, ImplementsCallableInterface1),
         (False, ImplementsCallableInterface1(1)),
-        (True, implements_callable_interface2),
+        (
+            False,
+            implements_callable_interface2,
+        ),  # TODO: switch to True once functions that implement protocol are checked correctly
         (False, NotImplementsCallableInterface1),
         (False, NotImplementsCallableInterface2),
         (False, NotImplementsCallableInterface3),
@@ -1818,3 +1823,7 @@ def test_subclass_error_indentation_in_union_invalid_value(parser):
     ).strip()
     expected = textwrap.indent(expected, "  ")
     assert "\n".join(expected.splitlines()) in "\n".join(err.splitlines())
+
+
+# if __name__ == "__main__":
+#     test_implements_protocol(True, ImplementsInterface)

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1484,6 +1484,55 @@ def test_parse_implements_protocol(parser):
         parser.parse_args(['--cls={"batch_size": 5}'])
     ctx.match("Not a valid subclass of Interface")
 
+# callable protocol tests
+
+class CallableInterface(Protocol):
+    def __call__(self, items: List[float]) -> List[float]: ...
+
+
+class ImplementsCallableInterface1:
+    def __init__(self, batch_size: int):
+        self.batch_size = batch_size
+
+    def __call__(self, items: List[float]) -> List[float]:
+        return items
+
+def implements_callable_interface2(items: List[float]) -> List[float]:
+    return items
+
+class NotImplementsCallableInterface1:
+    def __call__(self, items: str) -> List[float]:
+        return []
+
+
+class NotImplementsCallableInterface2:
+    def __call__(self, items: List[float], extra: int) -> List[float]:
+        return items
+
+
+class NotImplementsCallableInterface3:
+    def __call__(self, items: List[float]) -> None:
+        return
+
+
+def not_implements_callable_interface4(items: str) -> List[float]:
+    return []
+
+@pytest.mark.parametrize(
+    "expected, value",
+    [
+        (True, ImplementsCallableInterface1),
+        (False, ImplementsCallableInterface1(1)),
+        (True, implements_callable_interface2),
+        (False, NotImplementsCallableInterface1),
+        (False, NotImplementsCallableInterface2),
+        (False, NotImplementsCallableInterface3),
+        (False, not_implements_callable_interface4),
+        (False, object),
+    ],
+)
+def test_implements_callable_protocol(expected, value):
+    assert implements_protocol(value, CallableInterface) is expected
 
 # parameter skip tests
 

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1515,11 +1515,6 @@ class ImplementsCallableInterface1:
         return items
 
 
-# TODO: make functions that implement protocol be checked correctly
-def implements_callable_interface2(items: List[float]) -> List[float]:
-    return items
-
-
 class NotImplementsCallableInterface1:
     def __call__(self, items: str) -> List[float]:
         return []
@@ -1535,24 +1530,14 @@ class NotImplementsCallableInterface3:
         return
 
 
-# TODO: make functions that implement protocol be checked correctly
-def not_implements_callable_interface4(items: str) -> List[float]:
-    return []
-
-
 @pytest.mark.parametrize(
     "expected, value",
     [
         (True, ImplementsCallableInterface1),
         (False, ImplementsCallableInterface1(1)),
-        (
-            False,
-            implements_callable_interface2,
-        ),  # TODO: switch to True once functions that implement protocol are checked correctly
         (False, NotImplementsCallableInterface1),
         (False, NotImplementsCallableInterface2),
         (False, NotImplementsCallableInterface3),
-        (False, not_implements_callable_interface4),
         (False, object),
     ],
 )

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1484,7 +1484,9 @@ def test_parse_implements_protocol(parser):
         parser.parse_args(['--cls={"batch_size": 5}'])
     ctx.match("Not a valid subclass of Interface")
 
+
 # callable protocol tests
+
 
 class CallableInterface(Protocol):
     def __call__(self, items: List[float]) -> List[float]: ...
@@ -1497,8 +1499,10 @@ class ImplementsCallableInterface1:
     def __call__(self, items: List[float]) -> List[float]:
         return items
 
+
 def implements_callable_interface2(items: List[float]) -> List[float]:
     return items
+
 
 class NotImplementsCallableInterface1:
     def __call__(self, items: str) -> List[float]:
@@ -1518,6 +1522,7 @@ class NotImplementsCallableInterface3:
 def not_implements_callable_interface4(items: str) -> List[float]:
     return []
 
+
 @pytest.mark.parametrize(
     "expected, value",
     [
@@ -1533,6 +1538,7 @@ def not_implements_callable_interface4(items: str) -> List[float]:
 )
 def test_implements_callable_protocol(expected, value):
     assert implements_protocol(value, CallableInterface) is expected
+
 
 # parameter skip tests
 


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Fixes callable protocol inheritance by allowing a list of private methods to be considered when matching signatures for inheritance of subclasses.  The set of `allowed_dunder_methods` currently only contains the `__call__` method.

Fixes #595

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ ] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
