### PR TITLE
Fix missing use of prev vals for callables returning class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,14 +27,14 @@ Fixed
 - Required and optional ``TypedDict`` keys are now correctly inferred when one
   inherits one ``TypedDict`` from another with different totality (`#597
   <https://github.com/omni-us/jsonargparse/pull/597>`__).
-- Callables that return class not considering previous values (`#???
-  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+- Callables that return class not considering previous values (`#603
+  <https://github.com/omni-us/jsonargparse/pull/603>`__).
 
 Changed
 ^^^^^^^
 - Callables that return class with class default now normalizes the default to
-  a subclass spec with ``class_path`` (`#???
-  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  a subclass spec with ``class_path`` (`#603
+  <https://github.com/omni-us/jsonargparse/pull/603>`__).
 
 
 v4.33.2 (2024-10-07)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,14 @@ Fixed
 - Required and optional ``TypedDict`` keys are now correctly inferred when one
   inherits one ``TypedDict`` from another with different totality (`#597
   <https://github.com/omni-us/jsonargparse/pull/597>`__).
+- Callables that return class not considering previous values (`#???
+  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
+Changed
+^^^^^^^
+- Callables that return class with class default now normalizes the default to
+  a subclass spec with ``class_path`` (`#???
+  <https://github.com/omni-us/jsonargparse/pull/???>`__).
 
 
 v4.33.2 (2024-10-07)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -1336,7 +1336,6 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         cfg_to = cfg_to.clone()
         with parser_context(parent_parser=self):
             ActionTypeHint.discard_init_args_on_class_path_change(self, cfg_to, cfg_from)
-        ActionTypeHint.delete_init_args_required_none(cfg_from, cfg_to)
         ActionTypeHint.delete_not_required_args(cfg_from, cfg_to)
         cfg_to.update(cfg_from)
         ActionTypeHint.apply_appends(self, cfg_to)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -433,21 +433,6 @@ class ActionTypeHint(Action):
             num += 1
 
     @staticmethod
-    def delete_init_args_required_none(cfg_from, cfg_to):
-        for key, val in cfg_from.items(branches=True):
-            if isinstance(val, Namespace) and val.get("class_path") and val.get("init_args"):
-                skip_keys = [
-                    k
-                    for k, v in val.init_args.__dict__.items()
-                    if v is None and cfg_to.get(f"{key}.init_args.{k}") is not None
-                ]
-                if skip_keys:
-                    parser = ActionTypeHint.get_class_parser(val.class_path)
-                    for skip_key in skip_keys:
-                        if skip_key in parser.required_args:
-                            del val.init_args[skip_key]
-
-    @staticmethod
     def delete_not_required_args(cfg_from, cfg_to):
         for key, val in list(cfg_to.items(branches=True)):
             if val == inspect._empty and key not in cfg_from:
@@ -1171,8 +1156,6 @@ def subclass_spec_as_namespace(val, prev_val=None):
         val = Namespace({root_key: val})
         if isinstance(prev_val, str):
             prev_val = Namespace(class_path=prev_val)
-        elif inspect.isclass(prev_val):
-            prev_val = Namespace(class_path=get_import_path(prev_val))
     if isinstance(val, dict):
         val = Namespace(val)
     if "init_args" in val and isinstance(val["init_args"], dict):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -409,7 +409,7 @@ class ActionTypeHint(Action):
 
     @staticmethod
     def discard_init_args_on_class_path_change(parser_or_action, prev_cfg, cfg):
-        if isinstance(prev_cfg, dict) or cfg is None:
+        if isinstance(prev_cfg, dict):
             return
         keys = list(prev_cfg.keys(branches=True))
         num = 0

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -274,6 +274,8 @@ class ActionTypeHint(Action):
             default_type = type(default)
             if not is_subclass(default_type, UnknownDefault) and self.is_subclass_typehint(default_type):
                 raise ValueError("Subclass types require as default either a dict with class_path or a lazy instance.")
+        elif ActionTypeHint.is_return_subclass_typehint(self._typehint) and inspect.isclass(default):
+            default = {"class_path": get_import_path(default)}
         return default
 
     @staticmethod
@@ -407,7 +409,7 @@ class ActionTypeHint(Action):
 
     @staticmethod
     def discard_init_args_on_class_path_change(parser_or_action, prev_cfg, cfg):
-        if isinstance(prev_cfg, dict):
+        if isinstance(prev_cfg, dict) or cfg is None:
             return
         keys = list(prev_cfg.keys(branches=True))
         num = 0
@@ -1021,6 +1023,7 @@ def adapt_typehints(
                         sub_add_kwargs,
                         skip_args=num_partial_args,
                         partial_classes=partial_classes,
+                        prev_val=prev_val,
                     )
             except (ImportError, AttributeError, ArgumentError) as ex:
                 raise_unexpected_value(f"Type {typehint} expects a function or a callable class: {ex}", val, ex)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -940,6 +940,7 @@ def test_callable_args_return_type_class(parser, subtests):
 
     with subtests.test("default"):
         cfg = parser.get_defaults()
+        assert cfg.optimizer.class_path == f"{__name__}.SGD"
         init = parser.instantiate_classes(cfg)
         optimizer = init.optimizer([0.1, 2, 3])
         assert isinstance(optimizer, SGD)


### PR DESCRIPTION
## What does this PR do?

Fixes #478

Also callables returning class with class default now normalizes the default to be subclass spec with `class_path`.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
