### PR TITLE
Fix list of nestes dataclass parsing and NotRequired having inspect._empty as default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,17 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.34.1 (2024-11-??)
+--------------------
+
+Fixed
+^^^^^
+- List of dataclass with nested dataclass attribute fails to parse (`#???
+  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+- ``NotRequired`` incorrectly having ``inspect._empty`` as default (`#???
+  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
+
 v4.34.0 (2024-11-08)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,10 +17,10 @@ v4.34.1 (2024-11-??)
 
 Fixed
 ^^^^^
-- List of dataclass with nested dataclass attribute fails to parse (`#???
-  <https://github.com/omni-us/jsonargparse/pull/???>`__).
-- ``NotRequired`` incorrectly having ``inspect._empty`` as default (`#???
-  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+- List of dataclass with nested dataclass attribute fails to parse (`#625
+  <https://github.com/omni-us/jsonargparse/pull/625>`__).
+- ``NotRequired`` incorrectly having ``inspect._empty`` as default (`#625
+  <https://github.com/omni-us/jsonargparse/pull/625>`__).
 
 
 v4.34.0 (2024-11-08)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -1342,7 +1342,6 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         cfg_to = cfg_to.clone()
         with parser_context(parent_parser=self):
             ActionTypeHint.discard_init_args_on_class_path_change(self, cfg_to, cfg_from)
-        ActionTypeHint.delete_not_required_args(cfg_from, cfg_to)
         cfg_to.update(cfg_from)
         ActionTypeHint.apply_appends(self, cfg_to)
         return cfg_to

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -442,6 +442,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
             if cfg_base:
                 cfg = self.merge_config(cfg_base, cfg)
 
+            cfg = self._apply_actions(cfg)
             cfg_apply = self._apply_actions(cfg_obj, prev_cfg=cfg)
             cfg = self.merge_config(cfg_apply, cfg)
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -3,7 +3,7 @@
 import dataclasses
 import inspect
 import re
-from argparse import ArgumentParser
+from argparse import SUPPRESS, ArgumentParser
 from contextlib import suppress
 from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
@@ -321,9 +321,12 @@ class SignatureArguments(LoggerProperty):
         annotation = param.annotation
         if default == inspect_empty:
             default = param.default
-            if default == inspect_empty and is_optional(annotation):
-                default = None
-        is_required = default == inspect_empty and get_typehint_origin(annotation) not in not_required_types
+            if default == inspect_empty:
+                if is_optional(annotation):
+                    default = None
+                elif get_typehint_origin(annotation) in not_required_types:
+                    default = SUPPRESS
+        is_required = default == inspect_empty
         src = get_parameter_origins(param.component, param.parent)
         skip_message = f'Skipping parameter "{name}" from "{src}" because of: '
         if not fail_untyped and annotation == inspect_empty:

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -432,12 +432,6 @@ class ActionTypeHint(Action):
             num += 1
 
     @staticmethod
-    def delete_not_required_args(cfg_from, cfg_to):
-        for key, val in list(cfg_to.items(branches=True)):
-            if val == inspect._empty and key not in cfg_from:
-                del cfg_to[key]
-
-    @staticmethod
     @contextmanager
     def subclass_arg_context(parser):
         subclass_arg_parser.set(parser)

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -337,6 +337,25 @@ def test_instantiate_dataclass_within_classes(parser):
 
 
 @dataclasses.dataclass
+class RequiredAttr:
+    an_int: int
+
+
+@dataclasses.dataclass
+class NestedRequiredAttr:
+    b: RequiredAttr
+
+
+def test_list_nested_dataclass_required_attr(parser):
+    parser.add_argument("--a", type=List[NestedRequiredAttr])
+    cfg = parser.parse_args(['--a=[{"b": {"an_int": 3}}]'])
+    assert cfg == Namespace(a=[Namespace(b=Namespace(an_int=3))])
+    init = parser.instantiate_classes(cfg)
+    assert isinstance(init.a[0].b, RequiredAttr)
+    assert isinstance(init.a[0], NestedRequiredAttr)
+
+
+@dataclasses.dataclass
 class WithAttrDocs:
     attr_str: str = "a"
     "attr_str description"


### PR DESCRIPTION
## What does this PR do?

Fixes #614

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
