### PR TITLE
Add support for print config argument to reuse the name of the config argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,12 +18,13 @@ v4.35.0 (2024-12-??)
 Added
 ^^^^^
 - Support for ``print config`` argument to reuse the name of the config argument
-  by using ``%s`` (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  by using ``%s`` (`#630 <https://github.com/omni-us/jsonargparse/pull/630>`__).
 
 Deprecated
 ^^^^^^^^^^
 - From v5.0.0 the print config argument will by default reuse the name of the
-  config argument as ``--print_%s`` instead of being always ``--print_config``.
+  config argument as ``--print_%s`` instead of being always ``--print_config``
+  (`#630 <https://github.com/omni-us/jsonargparse/pull/630>`__).
 
 
 v4.34.1 (2024-11-??)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,20 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.35.0 (2024-12-??)
+--------------------
+
+Added
+^^^^^
+- Support for ``print config`` argument to reuse the name of the config argument
+  by using ``%s`` (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
+Deprecated
+^^^^^^^^^^
+- From v5.0.0 the print config argument will by default reuse the name of the
+  config argument as ``--print_%s`` instead of being always ``--print_config``.
+
+
 v4.34.1 (2024-11-??)
 --------------------
 

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -181,6 +181,9 @@ class ActionConfigFile(Action):
     @staticmethod
     def _add_print_config_argument(container, action):
         if isinstance(action, ActionConfigFile) and getattr(container, "_print_config", None) is not None:
+            if "%s" in container._print_config:
+                container._print_config = container._print_config % action.dest
+            assert container._print_config.startswith("--")
             container.add_argument(container._print_config, action=_ActionPrintConfig)
 
     @staticmethod

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -219,7 +219,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
             formatter_class: Class for printing help messages.
             logger: Configures the logger, see :class:`.LoggerProperty`.
             version: Program version which will be printed by the --version argument.
-            print_config: Add this as argument to print config, set None to disable.
+            print_config: Name for print config argument, ``%s`` is replaced by config dest, set None to disable.
             parser_mode: Mode for parsing config files: ``'yaml'``, ``'jsonnet'`` or ones added via :func:`.set_loader`.
             dump_header: Header to include as comment when dumping a config object.
             default_config_files: Default config file locations, e.g. ``['~/.config/myapp/*.yaml']``.

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -741,6 +741,14 @@ def test_print_config_empty_default_config_file(print_parser, tmp_cwd):
     assert yaml.safe_load(out) == {"g1": {"v2": "2"}, "g2": {"v3": None}, "v1": 1}
 
 
+def test_print_config_reuse_name():
+    parser = ArgumentParser(exit_on_error=False, print_config="--print_%s")
+    parser.add_argument("--conf", action="config")
+    parser.add_argument("--x", default=1)
+    out = get_parse_args_stdout(parser, ["--print_conf"])
+    assert yaml.safe_load(out) == {"x": 1}
+
+
 def test_default_config_files(parser, subtests, tmp_cwd):
     default_config_file = tmp_cwd / "defaults.yaml"
     default_config_file.write_text("op1: from default config file\n")


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
