### PR TITLE
Account for change in ArgumentParser._parse_known_args since Python 3.12.8 and 3.13.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,11 @@ Changed
   the help of the base class is printed (`#628
   <https://github.com/omni-us/jsonargparse/pull/628>`__).
 
+Fixed
+^^^^^
+- Account for change in ``ArgumentParser._parse_known_args`` since Python 3.12.8
+  and 3.13.1 (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
 Deprecated
 ^^^^^^^^^^
 - ``add_dataclass_arguments`` is deprecated and will be removed in v5.0.0.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changed
 Fixed
 ^^^^^
 - Account for change in ``ArgumentParser._parse_known_args`` since Python 3.12.8
-  and 3.13.1 (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  and 3.13.1 (`#644 <https://github.com/omni-us/jsonargparse/pull/644>`__).
 
 Deprecated
 ^^^^^^^^^^

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -95,6 +95,9 @@ from ._util import (
 __all__ = ["ActionsContainer", "ArgumentParser"]
 
 
+_parse_known_has_intermixed = "intermixed" in inspect.signature(argparse.ArgumentParser._parse_known_args).parameters
+
+
 class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
     """Extension of argparse._ActionsContainer to support additional functionalities."""
 
@@ -288,7 +291,10 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
             with patch_namespace(), parser_context(
                 parent_parser=self, lenient_check=True
             ), ActionTypeHint.subclass_arg_context(self):
-                namespace, args = self._parse_known_args(args, namespace)
+                kwargs = {}
+                if _parse_known_has_intermixed:
+                    kwargs["intermixed"] = False
+                namespace, args = self._parse_known_args(args, namespace, **kwargs)
         except argparse.ArgumentError as ex:
             self.error(str(ex), ex)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #641

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
