### PR TITLE
Fail when Namespace is used as a type to make it clear about being unsupported

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Changed
   parameter of ``ArgumentParser.{dump, save, get_defaults}`` renamed to
   ``skip_validation`` (`#639
   <https://github.com/omni-us/jsonargparse/pull/639>`__).
+- Fail when ``Namespace`` is used as a type to make it clear about being
+  unsupported (`#656 <https://github.com/omni-us/jsonargparse/pull/656>`__).
 
 Fixed
 ^^^^^

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -299,6 +299,9 @@ class ActionTypeHint(Action):
         """Whether the given type hint is supported."""
         typehint = get_unaliased_type(typehint)
 
+        if is_subclass(typehint, Namespace):
+            raise ValueError("jsonargparse.Namespace is only intended for parsing results and not supported as a type.")
+
         supported = (
             typehint in root_types
             or get_typehint_origin(typehint) in root_types

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -67,6 +67,12 @@ def test_add_argument_failure_given_type_and_action(parser):
     ctx.match("Providing both type and action not allowed")
 
 
+@pytest.mark.parametrize("typehint", [Namespace, Optional[Namespace], Union[int, Namespace], List[Namespace]])
+def test_namespace_unsupported_as_type(parser, typehint):
+    with pytest.raises(ValueError, match="Namespace .* not supported as a type"):
+        parser.add_argument("--ns", type=typehint)
+
+
 # basic types tests
 
 


### PR DESCRIPTION
## What does this PR do?

Related to #653 and #345

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
