### PR TITLE
Added verification for strings that contain digits and a starting or ending 'e'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/668>`__)
 - Functions that create types now have ``TypeAlias`` return type to avoid mypy
   errors (`#671 <https://github.com/omni-us/jsonargparse/pull/671>`__).
+- Bug when parsing strings with digits and a starting or ending 'e' (`#672
+  <https://github.com/omni-us/jsonargparse/pull/673>`__).
 
 
 v4.36.0 (2025-01-17)

--- a/jsonargparse/_loaders_dumpers.py
+++ b/jsonargparse/_loaders_dumpers.py
@@ -30,7 +30,7 @@ def load_basic(value):
         return None
     if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
         return int(value)
-    if value.replace(".", "", 1).replace("e", "", 1).replace("-", "", 2).isdigit() and ("e" in value or "." in value):
+    if not value.startswith('e') and not value.endswith('e') and value.replace(".", "", 1).replace("e", "", 1).replace("-", "", 2).isdigit() and ("e" in value or "." in value):
         return float(value)
     return not_loaded
 

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -91,6 +91,12 @@ def test_dump_header_invalid(parser):
         parser.dump_header = True
 
 
+def test_load_value_digits_and_e():
+    with parser_context(load_value_mode="yaml"):
+        assert "e123" == load_value("e123")
+        assert "123e" == load_value("123e")
+
+
 @skip_if_no_pyyaml
 def test_load_value_dash():
     with parser_context(load_value_mode="yaml"):


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

It adds two conditions of the string passed to the **load_basic** function:
- The first ensures the string do not start with an 'e'
- The second ensures the string do not end with an 'e'

<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
