### PR TITLE
Fix add_class_arguments with dashes in the nested_key fail to instantiate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ v4.37.1 (2025-02-??)
 Fixed
 ^^^^^
 - ``add_class_arguments`` with dashes in the ``nested_key`` fail to instantiate
-  (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  (`#679 <https://github.com/omni-us/jsonargparse/pull/679>`__).
 
 
 v4.37.0 (2025-02-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.37.1 (2025-02-??)
+--------------------
+
+Fixed
+^^^^^
+- ``add_class_arguments`` with dashes in the ``nested_key`` fail to instantiate
+  (`#??? <https://github.com/omni-us/jsonargparse/pull/???>`__).
+
+
 v4.37.0 (2025-02-14)
 --------------------
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -546,7 +546,7 @@ class SignatureArguments(LoggerProperty):
             if config_load and nested_key is not None:
                 group.add_argument("--" + nested_key, action=_ActionConfigLoad(basetype=config_load_type))
             if inspect.isclass(obj) and nested_key is not None and instantiate:
-                group.dest = nested_key
+                group.dest = nested_key.replace("-", "_")
                 group.group_class = obj
                 group.instantiate_class = group_instantiate_class
         return group

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -243,7 +243,18 @@ def test_add_class_implemented_with_new(parser):
 
 class RequiredParams:
     def __init__(self, n: int, m: float):
-        pass
+        self.n = n
+        self.m = m
+
+
+def test_add_class_group_name_dash_required_parameters(parser):
+    parser.add_class_arguments(RequiredParams, "required-params")
+    assert "required-params" in parser.groups
+    cfg = parser.parse_args(["--required-params.n=6", "--required-params.m=0.9"])
+    init = parser.instantiate_classes(cfg)
+    assert isinstance(init.required_params, RequiredParams)
+    assert init.required_params.n == 6
+    assert init.required_params.m == 0.9
 
 
 def test_add_class_with_required_parameters(parser):


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/omni-us/jsonargparse/issues/301#issuecomment-2650949459

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
