### PR TITLE
validate now checks values before required so that errors related to wrong level in a config are easier to understand

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,8 +18,8 @@ v4.38.0 (2025-02-??)
 Changed
 ^^^^^^^
 - ``validate`` now checks values before required so that errors related to wrong
-  level in a config are easier to understand (`#???
-  <https://github.com/omni-us/jsonargparse/pull/???>`__).
+  level in a config are easier to understand (`#681
+  <https://github.com/omni-us/jsonargparse/pull/681>`__).
 
 Fixed
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.37.1 (2025-02-??)
+v4.38.0 (2025-02-??)
 --------------------
+
+Changed
+^^^^^^^
+- ``validate`` now checks values before required so that errors related to wrong
+  level in a config are easier to understand (`#???
+  <https://github.com/omni-us/jsonargparse/pull/???>`__).
 
 Fixed
 ^^^^^

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -72,9 +72,8 @@ def test_subcommands_not_given_when_many_subcommands(parser, subparser):
 
 
 def test_subcommands_missing_required_subargument(subcommands_parser):
-    with pytest.raises(ArgumentError) as ctx:
+    with pytest.raises(ArgumentError, match='Key "a.ap1" is required'):
         subcommands_parser.parse_args(["a"])
-    ctx.match('"a.ap1" is required')
 
 
 def test_subcommands_undefined_subargument(subcommands_parser):


### PR DESCRIPTION
## What does this PR do?

Fixes #322

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
