### PR TITLE
Fix regression parsing strings with omegaconf as the parser mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Fixed
 ^^^^^
 - ``add_class_arguments`` with dashes in the ``nested_key`` fail to instantiate
   (`#679 <https://github.com/omni-us/jsonargparse/pull/679>`__).
+- Regression parsing strings with omegaconf as the parser mode (`#686
+  <https://github.com/omni-us/jsonargparse/pull/686>`__).
 
 
 v4.37.0 (2025-02-14)

--- a/jsonargparse/_loaders_dumpers.py
+++ b/jsonargparse/_loaders_dumpers.py
@@ -329,7 +329,7 @@ def set_omegaconf_loader():
     if omegaconf_support and "omegaconf" not in loaders:
         from ._optionals import get_omegaconf_loader
 
-        set_loader("omegaconf", get_omegaconf_loader())
+        set_loader("omegaconf", get_omegaconf_loader(), get_loader_exceptions("yaml"))
 
 
 set_loader("jsonnet", jsonnet_load, get_loader_exceptions("jsonnet"))

--- a/jsonargparse_tests/conftest.py
+++ b/jsonargparse_tests/conftest.py
@@ -19,6 +19,7 @@ from jsonargparse._optionals import (
     fsspec_support,
     jsonnet_support,
     jsonschema_support,
+    omegaconf_support,
     pyyaml_available,
     set_docstring_parse_options,
     toml_load_available,
@@ -110,6 +111,8 @@ def parser_modes(test_function):
             parser_modes += ["yaml"]
         if jsonnet_support:
             parser_modes += ["jsonnet"]
+        if omegaconf_support:
+            parser_modes += ["omegaconf"]
     return pytest.mark.parametrize("parser", parser_modes, indirect=True)(test_function)
 
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -104,9 +104,10 @@ def test_str_number_value(parser, value):
 
 
 @parser_modes
-def test_str_yaml_constructor_error(parser):
+@pytest.mark.parametrize("value", ["{{something}}", "{foo"])
+def test_str_yaml_constructor_error(parser, value):
     parser.add_argument("--val", type=str)
-    assert "{{something}}" == parser.parse_args(["--val={{something}}"]).val
+    assert value == parser.parse_args([f"--val={value}"]).val
 
 
 @parser_modes


### PR DESCRIPTION
## What does this PR do?

Fixes #683

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
