### PR TITLE
Fix/type action restriction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,8 @@ Fixed
 - Regression parsing strings with omegaconf as the parser mode (`#686
   <https://github.com/omni-us/jsonargparse/pull/686>`__).
 - Help incorrectly showing environment variable name for ``--print_shtab``.
-
+- ``add_argument`` raises error when type is assigned with ``action=None``
+  (`#687 <https://github.com/omni-us/jsonargparse/issues/687>`__).
 
 v4.37.0 (2025-02-14)
 --------------------

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -122,7 +122,7 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
             enable_path: Whether to try parsing path/subconfig when argument is a complex type.
         """
         parser = self.parser if hasattr(self, "parser") else self
-        if "action" in kwargs:
+        if "action" in kwargs and kwargs["action"] is not None:
             if ActionParser._is_valid_action_parser(parser, kwargs["action"]):
                 return ActionParser._move_parser_actions(parser, args, kwargs)
             ActionConfigFile._ensure_single_config_argument(self, kwargs["action"])

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -122,7 +122,7 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
             enable_path: Whether to try parsing path/subconfig when argument is a complex type.
         """
         parser = self.parser if hasattr(self, "parser") else self
-        if "action" in kwargs and kwargs["action"] is not None:
+        if kwargs.get("action") is not None:
             if ActionParser._is_valid_action_parser(parser, kwargs["action"]):
                 return ActionParser._move_parser_actions(parser, args, kwargs)
             ActionConfigFile._ensure_single_config_argument(self, kwargs["action"])

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -280,7 +280,7 @@ class ActionTypeHint(Action):
 
     @staticmethod
     def prepare_add_argument(args, kwargs, enable_path, container, logger, sub_add_kwargs=None):
-        if "action" in kwargs and kwargs["action"] is not None:
+        if kwargs.get("action") is not None:
             raise ValueError("Providing both type and action not allowed.")
         typehint = kwargs.pop("type")
         if args[0].startswith("--") and ActionTypeHint.supports_append(typehint):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -280,7 +280,7 @@ class ActionTypeHint(Action):
 
     @staticmethod
     def prepare_add_argument(args, kwargs, enable_path, container, logger, sub_add_kwargs=None):
-        if "action" in kwargs:
+        if "action" in kwargs and kwargs["action"] is not None:
             raise ValueError("Providing both type and action not allowed.")
         typehint = kwargs.pop("type")
         if args[0].startswith("--") and ActionTypeHint.supports_append(typehint):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -68,6 +68,20 @@ def test_add_argument_failure_given_type_and_action(parser):
     ctx.match("Providing both type and action not allowed")
 
 
+def test_add_argument_given_type_and_null_action(parser):
+    parser.add_argument("--op1", type=Optional[bool], action=None)
+    assert parser.get_defaults().op1 is None
+
+
+@parser_modes
+def test_add_argument_str_edge_cases_type_and_null_action(parser):
+    parser.add_argument("--val", type=str, action=None)
+    assert parser.parse_args(["--val=e123"]).val == "e123"
+    assert parser.parse_args(["--val=123e"]).val == "123e"
+    val = "1" * 5000
+    assert parser.parse_args([f"--val={val}"]).val == val
+
+
 @pytest.mark.parametrize("typehint", [Namespace, Optional[Namespace], Union[int, Namespace], List[Namespace]])
 def test_namespace_unsupported_as_type(parser, typehint):
     with pytest.raises(ValueError, match="Namespace .* not supported as a type"):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -73,15 +73,6 @@ def test_add_argument_given_type_and_null_action(parser):
     assert parser.get_defaults().op1 is None
 
 
-@parser_modes
-def test_add_argument_str_edge_cases_type_and_null_action(parser):
-    parser.add_argument("--val", type=str, action=None)
-    assert parser.parse_args(["--val=e123"]).val == "e123"
-    assert parser.parse_args(["--val=123e"]).val == "123e"
-    val = "1" * 5000
-    assert parser.parse_args([f"--val={val}"]).val == val
-
-
 @pytest.mark.parametrize("typehint", [Namespace, Optional[Namespace], Union[int, Namespace], List[Namespace]])
 def test_namespace_unsupported_as_type(parser, typehint):
     with pytest.raises(ValueError, match="Namespace .* not supported as a type"):


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?

Fix https://github.com/omni-us/jsonargparse/issues/685
Now in `add_argument`, passing `action=None` behaves like call without argument `action`.

```py3
parser.add_argument(
    "--string",
    type=str,
    action=None,
    default="default",
    help="example string",
)
```
<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [ ] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
