### PR TITLE
Untyped parameters with None default no longer skipped when fail_untyped=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.39.0 (2025-03-??)
+--------------------
+
+Changed
+^^^^^^^
+- Untyped parameters with ``None`` default no longer skipped when
+  ``fail_untyped=True`` (`#697
+  <https://github.com/omni-us/jsonargparse/pull/697>`__).
+
+
 v4.38.0 (2025-03-26)
 --------------------
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -356,11 +356,7 @@ class SignatureArguments(LoggerProperty):
             default = None
             is_required = False
             is_required_link_target = True
-        if (
-            kind in {kinds.VAR_POSITIONAL, kinds.VAR_KEYWORD}
-            or (not is_required and name[0] == "_")
-            or (annotation == inspect_empty and not is_required and default is None)
-        ):
+        if kind in {kinds.VAR_POSITIONAL, kinds.VAR_KEYWORD} or (not is_required and name[0] == "_"):
             return
         elif skip and name in skip:
             self.logger.debug(skip_message + "Parameter requested to be skipped.")


### PR DESCRIPTION
## What does this PR do?

Fixes #696

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
