### PR TITLE
Resolve parameters completely from stubs when inspect.signature fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Added
 ^^^^^
 - Support ``shtab`` completion of ``Literal`` types (`#693
   <https://github.com/omni-us/jsonargparse/pull/693>`__).
+- Support for parsing optionals as positionals (`#692
+  <https://github.com/omni-us/jsonargparse/pull/692>`__).
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Added
   <https://github.com/omni-us/jsonargparse/pull/700>`__).
 - ``auto_cli`` now supports class ``@property`` (`#701
   <https://github.com/omni-us/jsonargparse/pull/701>`__).
+- Resolve parameters completely from stubs when ``inspect.signature`` fails
+  (`#698 <https://github.com/omni-us/jsonargparse/pull/698>`__).
 
 Changed
 ^^^^^^^
@@ -43,8 +45,6 @@ Added
 ^^^^^
 - Support ``shtab`` completion of ``Literal`` types (`#693
   <https://github.com/omni-us/jsonargparse/pull/693>`__).
-- Support for parsing optionals as positionals (`#692
-  <https://github.com/omni-us/jsonargparse/pull/692>`__).
 
 Changed
 ^^^^^^^


### PR DESCRIPTION
## What does this PR do?

When combined with https://github.com/JelleZijlstra/typeshed_client/pull/118 would eventually resolve torch functions

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
