### PR TITLE
config_read_mode and docstring_parse options can now be set using set_parsing_settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Changed
 - Untyped parameters with ``None`` default no longer skipped when
   ``fail_untyped=True`` (`#697
   <https://github.com/omni-us/jsonargparse/pull/697>`__).
+- ``config_read_mode`` and ``docstring_parse`` options can now be set using
+  ``set_parsing_settings`` (`#711
+  <https://github.com/omni-us/jsonargparse/pull/711>`__).
 
 Fixed
 ^^^^^
@@ -42,6 +45,15 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/709>`__).
 - List append nested in subclass not working (`#710
   <https://github.com/omni-us/jsonargparse/pull/710>`__).
+
+Deprecated
+^^^^^^^^^^
+- ``get_config_read_mode`` and ``set_docstring_parse_options`` are deprecated
+  and will be removed in v5.0.0, instead use ``set_parsing_settings`` (`#711
+  <https://github.com/omni-us/jsonargparse/pull/711>`__).
+- ``get_config_read_mode`` is deprecated and will be removed in v5.0.0. There will
+  be no replacement since this is considered internal (`#711
+  <https://github.com/omni-us/jsonargparse/pull/711>`__).
 
 
 v4.38.0 (2025-03-26)

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -701,10 +701,10 @@ triggered to check if it is accessible. To get the content of the parsed path,
 without needing to care if it is a local file or a URL, the
 :py:meth:`.Path.get_content` method Scan be used.
 
-If you import ``from jsonargparse import set_config_read_mode`` and then run
-``set_config_read_mode(urls_enabled=True)`` or
-``set_config_read_mode(fsspec_enabled=True)``, the following functions and
-classes will also support loading from URLs:
+If you import ``from jsonargparse import set_parsing_settings`` and then run
+``set_parsing_settings(config_read_mode_urls_enabled=True)`` or
+``set_parsing_settings(config_read_mode_fsspec_enabled=True)``, the following
+functions and classes will also support loading from URLs:
 :py:meth:`.ArgumentParser.parse_path`, :py:meth:`.ArgumentParser.get_defaults`
 (``default_config_files`` argument), `action="config"`,
 :class:`.ActionJsonSchema`, :class:`.ActionJsonnet` and :class:`.ActionParser`.
@@ -1576,9 +1576,9 @@ single style, this is inefficient. A single style can be configured as follows:
 .. testcode:: docstrings
 
     from docstring_parser import DocstringStyle
-    from jsonargparse import set_docstring_parse_options
+    from jsonargparse import set_parsing_settings
 
-    set_docstring_parse_options(style=DocstringStyle.REST)
+    set_parsing_settings(docstring_parse_style=DocstringStyle.REST)
 
 The second option that can be configured is the support for `attribute
 docstrings <https://peps.python.org/pep-0257/#what-is-a-docstring>`__ (i.e.
@@ -1589,9 +1589,9 @@ that don't have attribute docstrings. To enable, do as follows:
 .. testcode:: docstrings
 
     from dataclasses import dataclass
-    from jsonargparse import set_docstring_parse_options
+    from jsonargparse import set_parsing_settings
 
-    set_docstring_parse_options(attribute_docstrings=True)
+    set_parsing_settings(docstring_parse_attribute_docstrings=True)
 
 
     @dataclass
@@ -1606,8 +1606,8 @@ that don't have attribute docstrings. To enable, do as follows:
 
 .. testcleanup:: docstrings
 
-    set_docstring_parse_options(style=DocstringStyle.GOOGLE)
-    set_docstring_parse_options(attribute_docstrings=False)
+    set_parsing_settings(docstring_parse_style=DocstringStyle.GOOGLE)
+    set_parsing_settings(docstring_parse_attribute_docstrings=False)
 
 Customization of arguments
 --------------------------

--- a/jsonargparse/__init__.py
+++ b/jsonargparse/__init__.py
@@ -64,9 +64,9 @@ __all__ += _actions.__all__
 __all__ += _namespace.__all__
 __all__ += _formatters.__all__
 __all__ += _optionals.__all__
+__all__ += _common.__all__
 __all__ += _loaders_dumpers.__all__
 __all__ += _util.__all__
-__all__ += _common.__all__
 __all__ += _deprecated.__all__
 
 

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from ._common import Action, is_subclass, parser_context
 from ._loaders_dumpers import get_loader_exceptions, load_value
 from ._namespace import Namespace, NSKeyError, split_key, split_key_root
-from ._optionals import get_config_read_mode
+from ._optionals import _get_config_read_mode
 from ._type_checking import ActionsContainer, ArgumentParser
 from ._util import (
     Path,
@@ -194,7 +194,7 @@ class ActionConfigFile(Action):
         with _ActionSubCommands.not_single_subcommand(), previous_config_context(cfg), skip_apply_links():
             kwargs = {"env": False, "defaults": False, "_skip_validation": True, "_fail_no_subcommand": False}
             try:
-                cfg_path: Optional[Path] = Path(value, mode=get_config_read_mode())
+                cfg_path: Optional[Path] = Path(value, mode=_get_config_read_mode())
             except TypeError as ex_path:
                 try:
                     if isinstance(load_value(value), str):

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -6,6 +6,7 @@ import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import (  # type: ignore[attr-defined]
+    TYPE_CHECKING,
     Dict,
     Generic,
     List,
@@ -20,6 +21,8 @@ from typing import (  # type: ignore[attr-defined]
 
 from ._namespace import Namespace
 from ._optionals import (
+    _set_config_read_mode,
+    _set_docstring_parse_options,
     capture_typing_extension_shadows,
     get_alias_target,
     get_annotated_base_type,
@@ -30,6 +33,9 @@ from ._optionals import (
     typing_extensions_import,
 )
 from ._type_checking import ActionsContainer, ArgumentParser
+
+if TYPE_CHECKING:
+    import docstring_parser
 
 __all__ = [
     "LoggerProperty",
@@ -98,6 +104,10 @@ parsing_settings = dict(
 def set_parsing_settings(
     *,
     validate_defaults: Optional[bool] = None,
+    config_read_mode_urls_enabled: Optional[bool] = None,
+    config_read_mode_fsspec_enabled: Optional[bool] = None,
+    docstring_parse_style: Optional["docstring_parser.DocstringStyle"] = None,
+    docstring_parse_attribute_docstrings: Optional[bool] = None,
     parse_optionals_as_positionals: Optional[bool] = None,
 ) -> None:
     """
@@ -107,6 +117,14 @@ def set_parsing_settings(
         validate_defaults: Whether default values must be valid according to the
             argument type. The default is False, meaning no default validation,
             like in argparse.
+        config_read_mode_urls_enabled: Whether to read config files from URLs
+            using requests package. Default is False.
+        config_read_mode_fsspec_enabled: Whether to read config files from
+            fsspec supported file systems. Default is False.
+        docstring_parse_style: The docstring style to expect. Default is
+            DocstringStyle.AUTO.
+        docstring_parse_attribute_docstrings: Whether to parse attribute
+            docstrings (slower). Default is False.
         parse_optionals_as_positionals: [EXPERIMENTAL] If True, the parser will
             take extra positional command line arguments as values for optional
             arguments. This means that optional arguments can be given by name
@@ -114,10 +132,22 @@ def set_parsing_settings(
             are applied to optionals in the order that they were added to the
             parser. By default, this is False.
     """
+    # validate_defaults
     if isinstance(validate_defaults, bool):
         parsing_settings["validate_defaults"] = validate_defaults
     elif validate_defaults is not None:
         raise ValueError(f"validate_defaults must be a boolean, but got {validate_defaults}.")
+    # config_read_mode
+    if config_read_mode_urls_enabled is not None:
+        _set_config_read_mode(urls_enabled=config_read_mode_urls_enabled)
+    if config_read_mode_fsspec_enabled is not None:
+        _set_config_read_mode(fsspec_enabled=config_read_mode_fsspec_enabled)
+    # docstring_parse
+    if docstring_parse_style is not None:
+        _set_docstring_parse_options(style=docstring_parse_style)
+    if docstring_parse_attribute_docstrings is not None:
+        _set_docstring_parse_options(attribute_docstrings=docstring_parse_attribute_docstrings)
+    # parse_optionals_as_positionals
     if isinstance(parse_optionals_as_positionals, bool):
         parsing_settings["parse_optionals_as_positionals"] = parse_optionals_as_positionals
     elif parse_optionals_as_positionals is not None:

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -77,8 +77,8 @@ from ._namespace import (
     strip_meta,
 )
 from ._optionals import (
+    _get_config_read_mode,
     fsspec_support,
-    get_config_read_mode,
     import_fsspec,
     import_jsonnet,
     pyyaml_available,
@@ -619,7 +619,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
         Raises:
             ArgumentError: If the parsing fails error and exit_on_error=True.
         """
-        fpath = Path(cfg_path, mode=get_config_read_mode())
+        fpath = Path(cfg_path, mode=_get_config_read_mode())
         with change_to_path_dir(fpath):
             cfg_str = fpath.get_content()
             parsed_cfg = self.parse_string(
@@ -971,7 +971,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, argp
 
         if len(default_config_files) > 0:
             with suppress(TypeError):
-                return [(k, Path(v, mode=get_config_read_mode())) for k, v in default_config_files]
+                return [(k, Path(v, mode=_get_config_read_mode())) for k, v in default_config_files]
         return []
 
     def get_default(self, dest: str) -> Any:

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -22,6 +22,9 @@ __all__ = [
     "ActionPath",
     "ActionPathList",
     "ParserError",
+    "get_config_read_mode",
+    "set_docstring_parse_options",
+    "set_config_read_mode",
     "set_url_support",
     "usage_and_exit_error_handler",
 ]
@@ -350,16 +353,66 @@ class ActionPathList(Action):
     """
     set_url_support was deprecated in v3.12.0 and will be removed in v5.0.0.
     Optional config read modes should now be set using function
-    set_config_read_mode.
+    set_parsing_settings.
 """
 )
 def set_url_support(enabled: bool):
     """Enables/disables URL support for config read mode."""
-    from ._optionals import get_config_read_mode, set_config_read_mode
+    from ._optionals import _get_config_read_mode, _set_config_read_mode
 
-    set_config_read_mode(
+    _set_config_read_mode(
         urls_enabled=enabled,
-        fsspec_enabled=True if "s" in get_config_read_mode() else False,
+        fsspec_enabled=True if "s" in _get_config_read_mode() else False,
+    )
+
+
+@deprecated(
+    """
+    set_config_read_mode was deprecated in v4.39.0 and will be removed in
+    v5.0.0. Optional config read modes should now be set using function
+    set_parsing_settings.
+"""
+)
+def set_config_read_mode(
+    urls_enabled: bool = False,
+    fsspec_enabled: bool = False,
+):
+    """Enables/disables optional config read modes."""
+    from ._optionals import _set_config_read_mode
+
+    _set_config_read_mode(
+        urls_enabled=urls_enabled,
+        fsspec_enabled=fsspec_enabled,
+    )
+
+
+@deprecated(
+    """
+    get_config_read_mode was deprecated in v4.39.0 and will be removed in
+    v5.0.0. The config read mode is internal and thus shouldn't be used.
+"""
+)
+def get_config_read_mode() -> str:
+    """Returns the current config reading mode."""
+    from ._optionals import _get_config_read_mode
+
+    return _get_config_read_mode()
+
+
+@deprecated(
+    """
+    set_docstring_parse_options was deprecated in v4.39.0 and will be removed in
+    v5.0.0. Docstring parse options should now be set using function
+    set_parsing_settings.
+"""
+)
+def set_docstring_parse_options(style=None, attribute_docstrings: Optional[bool] = None):
+    """Sets options for docstring parsing."""
+    from ._optionals import _set_docstring_parse_options
+
+    _set_docstring_parse_options(
+        style=style,
+        attribute_docstrings=attribute_docstrings,
     )
 
 

--- a/jsonargparse/_jsonnet.py
+++ b/jsonargparse/_jsonnet.py
@@ -7,7 +7,7 @@ from ._common import Action, parser_context
 from ._jsonschema import ActionJsonSchema
 from ._loaders_dumpers import get_loader_exceptions, load_value
 from ._optionals import (
-    get_config_read_mode,
+    _get_config_read_mode,
     get_jsonschema_exceptions,
     import_jsonnet,
     import_jsonschema,
@@ -157,7 +157,7 @@ class ActionJsonnet(Action):
         fname = "snippet"
         snippet = jsonnet
         try:
-            fpath = Path(jsonnet, mode=get_config_read_mode())
+            fpath = Path(jsonnet, mode=_get_config_read_mode())
         except TypeError:
             pass
         else:

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -8,9 +8,7 @@ from importlib.util import find_spec
 from typing import Optional, Union
 
 __all__ = [
-    "get_config_read_mode",
-    "set_config_read_mode",
-    "set_docstring_parse_options",
+    "_get_config_read_mode",
 ]
 
 
@@ -165,7 +163,7 @@ def import_reconplogger(importer):
     return reconplogger
 
 
-def set_config_read_mode(
+def _set_config_read_mode(
     urls_enabled: bool = False,
     fsspec_enabled: bool = False,
 ):
@@ -183,7 +181,7 @@ def set_config_read_mode(
     def update_mode(flag, enabled):
         global _config_read_mode
         if enabled:
-            imports[flag]("set_config_read_mode")
+            imports[flag]("_set_config_read_mode")
             if flag not in _config_read_mode:
                 _config_read_mode = _config_read_mode.replace("f", "f" + flag)
         else:
@@ -193,12 +191,12 @@ def set_config_read_mode(
     update_mode("s", fsspec_enabled)
 
 
-def get_config_read_mode() -> str:
+def _get_config_read_mode() -> str:
     """Returns the current config reading mode."""
     return _config_read_mode
 
 
-def set_docstring_parse_options(style=None, attribute_docstrings: Optional[bool] = None):
+def _set_docstring_parse_options(style=None, attribute_docstrings: Optional[bool] = None):
     """Sets options for docstring parsing.
 
     Args:
@@ -206,7 +204,7 @@ def set_docstring_parse_options(style=None, attribute_docstrings: Optional[bool]
         attribute_docstrings: Whether to parse attribute docstrings (slower).
     """
     global _docstring_parse_options
-    dp = import_docstring_parser("set_docstring_parse_options")
+    dp = import_docstring_parser("_set_docstring_parse_options")
     if style is not None:
         if not isinstance(style, dp.DocstringStyle):
             raise ValueError(f"Expected style to be of type {dp.DocstringStyle}.")

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -870,9 +870,9 @@ def adapt_typehints(
         list_path = None
         if enable_path and type(val) is str:
             with suppress(TypeError):
-                from ._optionals import get_config_read_mode
+                from ._optionals import _get_config_read_mode
 
-                list_path = Path(val, mode=get_config_read_mode())
+                list_path = Path(val, mode=_get_config_read_mode())
                 val = list_path.get_content().splitlines()
         if isinstance(val, NestedArg) and subtypehints is not None:
             val = (prev_val[:-1] if isinstance(prev_val, list) else []) + [val]

--- a/jsonargparse/_util.py
+++ b/jsonargparse/_util.py
@@ -39,8 +39,8 @@ from ._common import (
 from ._deprecated import PathDeprecations
 from ._loaders_dumpers import json_compact_dump, load_value
 from ._optionals import (
+    _get_config_read_mode,
     fsspec_support,
-    get_config_read_mode,
     import_fsspec,
     import_requests,
     url_support,
@@ -135,7 +135,7 @@ def parse_value_or_config(
     cfg_path = None
     if enable_path and type(value) is str and value != "-":
         try:
-            cfg_path = Path(value, mode=get_config_read_mode())
+            cfg_path = Path(value, mode=_get_config_read_mode())
         except TypeError:
             pass
         else:

--- a/jsonargparse_tests/conftest.py
+++ b/jsonargparse_tests/conftest.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from jsonargparse import ArgumentParser
+from jsonargparse import ArgumentParser, set_parsing_settings
 from jsonargparse._loaders_dumpers import json_compact_dump, json_load, yaml_dump, yaml_load
 from jsonargparse._optionals import (
     docstring_parser_support,
@@ -21,7 +21,6 @@ from jsonargparse._optionals import (
     jsonschema_support,
     omegaconf_support,
     pyyaml_available,
-    set_docstring_parse_options,
     toml_load_available,
     url_support,
 )
@@ -29,7 +28,7 @@ from jsonargparse._optionals import (
 if docstring_parser_support:
     from docstring_parser import DocstringStyle
 
-    set_docstring_parse_options(style=DocstringStyle.GOOGLE)
+    set_parsing_settings(docstring_parse_style=DocstringStyle.GOOGLE)
 
 
 columns = "200"

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -21,7 +21,7 @@ from jsonargparse import (
     ArgumentError,
     ArgumentParser,
     Namespace,
-    set_config_read_mode,
+    set_parsing_settings,
     strip_meta,
 )
 from jsonargparse._formatters import get_env_var
@@ -579,7 +579,7 @@ def parser_schema_jsonnet(parser, example_parser):
 def test_parse_args_url_config(parser_schema_jsonnet):
     import responses
 
-    set_config_read_mode(urls_enabled=True)
+    set_parsing_settings(config_read_mode_urls_enabled=True)
     parser, expected, subparser_body, schema_body, jsonnet_body = parser_schema_jsonnet
 
     base_url = "http://jsonargparse.com/"
@@ -606,7 +606,7 @@ def test_parse_args_url_config(parser_schema_jsonnet):
     if jsonnet_support:
         assert expected.jsonnet == cfg.jsonnet
 
-    set_config_read_mode(urls_enabled=False)
+    set_parsing_settings(config_read_mode_urls_enabled=False)
 
 
 def test_save_multifile(parser_schema_jsonnet, subtests, tmp_cwd):

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -8,14 +8,20 @@ from unittest.mock import patch
 
 import pytest
 
-from jsonargparse import ArgumentError, ArgumentParser, Namespace, compose_dataclasses, lazy_instance
+from jsonargparse import (
+    ArgumentError,
+    ArgumentParser,
+    Namespace,
+    compose_dataclasses,
+    lazy_instance,
+    set_parsing_settings,
+)
 from jsonargparse._namespace import NSKeyError
 from jsonargparse._optionals import (
     attrs_support,
     docstring_parser_support,
     pydantic_support,
     pydantic_supports_field_init,
-    set_docstring_parse_options,
     typing_extensions_import,
 )
 from jsonargparse.typing import PositiveFloat, PositiveInt, final
@@ -385,7 +391,7 @@ class WithAttrDocs:
 @skip_if_docstring_parser_unavailable
 @patch.dict("jsonargparse._optionals._docstring_parse_options")
 def test_attribute_docstrings(parser):
-    set_docstring_parse_options(attribute_docstrings=True)
+    set_parsing_settings(docstring_parse_attribute_docstrings=True)
     parser.add_class_arguments(WithAttrDocs)
     help_str = get_parser_help(parser)
     assert "attr_str description (type: str, default: a)" in help_str

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -20,7 +20,6 @@ from jsonargparse import (
     LoggerProperty,
     Namespace,
     Path,
-    get_config_read_mode,
     set_url_support,
 )
 from jsonargparse._deprecated import (
@@ -34,7 +33,13 @@ from jsonargparse._deprecated import (
     shown_deprecation_warnings,
     usage_and_exit_error_handler,
 )
-from jsonargparse._optionals import docstring_parser_support, jsonnet_support, pyyaml_available, url_support
+from jsonargparse._optionals import (
+    _get_config_read_mode,
+    docstring_parser_support,
+    jsonnet_support,
+    pyyaml_available,
+    url_support,
+)
 from jsonargparse._util import argument_error
 from jsonargparse_tests.conftest import (
     get_parser_help,
@@ -181,7 +186,7 @@ def test_ActionOperators():
 
 @skip_if_requests_unavailable
 def test_url_support_true():
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
     with catch_warnings(record=True) as w:
         set_url_support(True)
     assert_deprecation_warn(
@@ -189,21 +194,21 @@ def test_url_support_true():
         message="set_url_support was deprecated",
         code="set_url_support(True)",
     )
-    assert "fur" == get_config_read_mode()
+    assert "fur" == _get_config_read_mode()
     set_url_support(False)
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
 
 
 @pytest.mark.skipif(url_support, reason="requests package should not be installed")
 def test_url_support_false():
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
     with catch_warnings(record=True) as w:
         with pytest.raises(ImportError):
             set_url_support(True)
         assert "set_url_support was deprecated" in str(w[-1].message)
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
     set_url_support(False)
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
 
 
 def test_instantiate_subclasses():

--- a/jsonargparse_tests/test_optionals.py
+++ b/jsonargparse_tests/test_optionals.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from jsonargparse import get_config_read_mode, set_config_read_mode
+from jsonargparse import set_parsing_settings
 from jsonargparse._optionals import (
+    _get_config_read_mode,
     docstring_parser_support,
     fsspec_support,
     get_docstring_parse_options,
@@ -16,7 +17,6 @@ from jsonargparse._optionals import (
     jsonnet_support,
     jsonschema_support,
     ruyaml_support,
-    set_docstring_parse_options,
     url_support,
 )
 from jsonargparse_tests.conftest import (
@@ -94,17 +94,17 @@ def test_docstring_parse_options():
     options = get_docstring_parse_options()
 
     for style in [DocstringStyle.NUMPYDOC, DocstringStyle.GOOGLE]:
-        set_docstring_parse_options(style=style)
+        set_parsing_settings(docstring_parse_style=style)
         assert options["style"] == style
     with pytest.raises(ValueError):
-        set_docstring_parse_options(style="invalid")
+        set_parsing_settings(docstring_parse_style="invalid")
 
     assert options["attribute_docstrings"] is False
     for attribute_docstrings in [True, False]:
-        set_docstring_parse_options(attribute_docstrings=attribute_docstrings)
+        set_parsing_settings(docstring_parse_attribute_docstrings=attribute_docstrings)
         assert options["attribute_docstrings"] is attribute_docstrings
     with pytest.raises(ValueError):
-        set_docstring_parse_options(attribute_docstrings="invalid")
+        set_parsing_settings(docstring_parse_attribute_docstrings="invalid")
 
 
 # fsspec support
@@ -142,37 +142,37 @@ def test_ruyaml_support_false():
 
 @skip_if_requests_unavailable
 def test_config_read_mode_url_support_true():
-    assert "fr" == get_config_read_mode()
-    set_config_read_mode(urls_enabled=True)
-    assert "fur" == get_config_read_mode()
-    set_config_read_mode(urls_enabled=False)
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_urls_enabled=True)
+    assert "fur" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_urls_enabled=False)
+    assert "fr" == _get_config_read_mode()
 
 
 @pytest.mark.skipif(url_support, reason="request package should not be installed")
 def test_config_read_mode_url_support_false():
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
     with pytest.raises(ImportError):
-        set_config_read_mode(urls_enabled=True)
-    assert "fr" == get_config_read_mode()
-    set_config_read_mode(urls_enabled=False)
-    assert "fr" == get_config_read_mode()
+        set_parsing_settings(config_read_mode_urls_enabled=True)
+    assert "fr" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_urls_enabled=False)
+    assert "fr" == _get_config_read_mode()
 
 
 @skip_if_fsspec_unavailable
 def test_config_read_mode_fsspec_support_true():
-    assert "fr" == get_config_read_mode()
-    set_config_read_mode(fsspec_enabled=True)
-    assert "fsr" == get_config_read_mode()
-    set_config_read_mode(fsspec_enabled=False)
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_fsspec_enabled=True)
+    assert "fsr" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_fsspec_enabled=False)
+    assert "fr" == _get_config_read_mode()
 
 
 @pytest.mark.skipif(fsspec_support, reason="fsspec package should not be installed")
 def test_config_read_mode_fsspec_support_false():
-    assert "fr" == get_config_read_mode()
+    assert "fr" == _get_config_read_mode()
     with pytest.raises(ImportError):
-        set_config_read_mode(fsspec_enabled=True)
-    assert "fr" == get_config_read_mode()
-    set_config_read_mode(fsspec_enabled=False)
-    assert "fr" == get_config_read_mode()
+        set_parsing_settings(config_read_mode_fsspec_enabled=True)
+    assert "fr" == _get_config_read_mode()
+    set_parsing_settings(config_read_mode_fsspec_enabled=False)
+    assert "fr" == _get_config_read_mode()


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
