### PR TITLE
Fix validate_defaults=True fails when the parser has a config action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.40.0 (2025-05-??)
+--------------------
+
+Fixed
+^^^^^
+- ``set_parsing_settings(validate_defaults=True)`` fails when the parser has a
+  config action (`#718 <https://github.com/omni-us/jsonargparse/pull/718>`__).
+
+
 v4.39.0 (2025-04-29)
 --------------------
 

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -159,13 +159,13 @@ def get_parsing_setting(name: str):
 
 
 def validate_default(container: ActionsContainer, action: argparse.Action):
-    if not isinstance(action, Action) or not get_parsing_setting("validate_defaults") or action.default is None:
+    if action.default is None or not get_parsing_setting("validate_defaults") or not hasattr(action, "_check_type"):
         return
     try:
         with parser_context(parent_parser=container):
             default = action.default
             action.default = None
-            action.default = action._check_type_(default)
+            action.default = action._check_type_(default)  # type: ignore[attr-defined]
     except Exception as ex:
         raise ValueError(f"Default value is not valid: {ex}") from ex
 

--- a/jsonargparse_tests/test_parsing_settings.py
+++ b/jsonargparse_tests/test_parsing_settings.py
@@ -33,6 +33,7 @@ def test_set_validate_defaults_failure():
 def test_validate_defaults_success(parser):
     set_parsing_settings(validate_defaults=True)
 
+    parser.add_argument("--config", action="config")
     parser.add_argument("--num", type=int, default=1)
     parser.add_argument("--untyped", default=2)
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/omni-us/jsonargparse/issues/237#issuecomment-2840020852

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
