### PR TITLE
Fix stubs-only resolver incorrectly triggered when inspect.signature available leading to missing parameter defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,9 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/717>`__).
 - ``TypedDict`` values not validated when types are forward references (`#722
   <https://github.com/omni-us/jsonargparse/pull/722>`__).
+- Stubs-only resolver incorrectly triggered when ``inspect.signature`` available
+  leading to missing parameter defaults (`#724
+  <https://github.com/omni-us/jsonargparse/pull/724>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -1042,6 +1042,11 @@ def get_parameters_from_stubs(
     logger: logging.Logger,
 ) -> Optional[ParamList]:
     component, parent, _ = get_component_and_parent(function_or_class, method_or_property)
+    try:
+        inspect.signature(component)
+        return None
+    except Exception:
+        pass  # only from stubs if getting signature fails
     params = None
     resolver = get_stubs_resolver()
     stub_import = resolver.get_component_imported_info(component, parent)

--- a/jsonargparse_tests/conftest.py
+++ b/jsonargparse_tests/conftest.py
@@ -185,7 +185,7 @@ def capture_logs(logger: logging.Logger) -> Iterator[StringIO]:
 
 @contextmanager
 def source_unavailable():
-    with patch("inspect.getsource", side_effect=OSError("could not get source code")):
+    with patch("inspect.getsource", side_effect=OSError("mock source code not available")):
         yield
 
 

--- a/jsonargparse_tests/test_postponed_annotations.py
+++ b/jsonargparse_tests/test_postponed_annotations.py
@@ -73,7 +73,7 @@ def test_get_types_pep604():
 def test_get_types_pep604_source_unavailable(logger):
     with source_unavailable(), pytest.raises(TypeError) as ctx, capture_logs(logger) as logs:
         get_types(function_pep604, logger)
-    ctx.match("could not get source code")
+    ctx.match("mock source code not available")
     assert "Failed to parse to source code" in logs.getvalue()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ all = [
 signatures = [
     "jsonargparse[typing-extensions]",
     "docstring-parser>=0.15",
-    "typeshed-client>=2.1.0",
+    "typeshed-client>=2.3.0",
 ]
 jsonschema = [
     "jsonschema>=3.2.0",


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [ ] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
