### PR TITLE
Fix hyphen parser with default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Fixed
 - ``adapt_class_type`` used a locally defined `partial_instance` wrapper
   function that is not pickleable (`#728
   <https://github.com/omni-us/jsonargparse/pull/728>`__).
+- ArgumentParser with dashes incorrectly resolves paths to default values()
 
 
 v4.40.0 (2025-05-16)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -201,6 +201,7 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
         """
         for arg in args:
             for dest, default in arg.items():
+                dest = dest.replace("-", "_")
                 action = _find_action(self, dest)
                 if action is None:
                     raise NSKeyError(f'No action for key "{dest}" to set its default.')
@@ -458,7 +459,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
                 cfg, unk = self.parse_known_args(args=args, namespace=cfg)
                 cfg, unk = self._positional_optionals(cfg, unk)
             if unk:
-                self.error(f'Unrecognized arguments: {" ".join(unk)}')
+                self.error(f"Unrecognized arguments: {' '.join(unk)}")
 
             parsed_cfg = self._parse_common(
                 cfg=cfg,

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -115,6 +115,14 @@ class NestedDefaultsA:
 class NestedDefaultsB:
     a: List[NestedDefaultsA]
 
+@dataclasses.dataclass
+class NestedDefaultsC:
+    field_with_dash: int = 5
+
+@dataclasses.dataclass
+class NestedDefaultsD:
+    c_with_dash: NestedDefaultsC = dataclasses.field(default_factory=NestedDefaultsC)
+
 
 def test_add_dataclass_nested_defaults(parser):
     parser.add_class_arguments(NestedDefaultsB, "data")
@@ -988,6 +996,18 @@ class TestPydantic:
         init = parser.instantiate_classes(cfg)
         assert isinstance(init.model, PydanticNestedDict)
         assert isinstance(init.model.nested["key"], NestedModel)
+
+    def test_dashes_in_nested_dataclass(self):
+        class UnderscoresToDashesParser(ArgumentParser):
+            def add_argument(self, *args, **kwargs):
+                args = [arg.replace("_", "-") for arg in args]
+                return super().add_argument(*args, **kwargs)
+
+        parser = UnderscoresToDashesParser(parse_as_dict=False, default_env=True)
+        parser.add_class_arguments(NestedDefaultsD)
+        ns = parser.parse_args([])
+        cfg = parser.instantiate_classes(ns)
+        assert cfg.c_with_dash.field_with_dash == 5
 
 
 # attrs tests

--- a/jsonargparse_tests/test_dataclass_like.py
+++ b/jsonargparse_tests/test_dataclass_like.py
@@ -115,9 +115,11 @@ class NestedDefaultsA:
 class NestedDefaultsB:
     a: List[NestedDefaultsA]
 
+
 @dataclasses.dataclass
 class NestedDefaultsC:
     field_with_dash: int = 5
+
 
 @dataclasses.dataclass
 class NestedDefaultsD:


### PR DESCRIPTION
<!--
Thank you very much for contributing! If you like this project, please ⭐ star it
https://github.com/omni-us/jsonargparse/
-->

## What does this PR do?
Fixing:  #731
Using dashes (or hyphens) is sometimes more common and `jsonargparse` supports this (see #301). However, when resolving default values for arguments in a nested dataclass, it does not normalize arguments with underscores, which results in `NSKeyError` (see the issue).
  
<!--
Concisely describe what this pull request does. If available, include links to
issues web pages where the need for this change has been motivated.
-->
This PR adds the normalization line `dest = dest.replace("-", "_")` that resolves the problem. 

## Before submitting

<!--
Use the following list as tasks to be completed before marking a pull request as
"Ready for review". Fill with an "x" all tasks done. Use "n/a" if you think a
task is not relevant or leave empty when in doubt.
-->

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
