### PR TITLE
Require new version of docstring-parser to avoid deprecation warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ The semantic versioning only considers the public API as described in
 :ref:`api-ref`. Components not mentioned in :ref:`api-ref` or different import
 paths are considered internals and can change in minor and patch releases.
 
+
 v4.40.1 (2025-05-??)
 --------------------
 
@@ -25,6 +26,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/736>`__).
 - Fix failing tests due to new version of ``typeshed-client`` (`#740
   <https://github.com/omni-us/jsonargparse/pull/740>`__).
+- Require new version of ``docstring-parser`` to avoid deprecation warnings
+  (`#741 <https://github.com/omni-us/jsonargparse/pull/741>`__).
 
 
 v4.40.0 (2025-05-16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ all = [
 ]
 signatures = [
     "jsonargparse[typing-extensions]",
-    "docstring-parser>=0.15",
+    "docstring-parser>=0.17",
     "typeshed-client>=2.3.0; python_version == '3.8'",
     "typeshed-client>=2.8.2; python_version >= '3.9'",
 ]


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
