### PR TITLE
Split YAMLCommentFormatter from the help formatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,8 +31,9 @@ Changed
 Deprecated
 ^^^^^^^^^^
 - ``DefaultHelpFormatter.*_yaml*_comment*`` methods are deprecated and will be
-  removed in v5.0.0. Instead use the new class ``YAMLCommentFormatter`` (`#754
-  <https://github.com/omni-us/jsonargparse/pull/754>`__).
+  removed in v5.0.0. This logic has been moved to a new private class
+  ``YAMLCommentFormatter``. If deemed necessary, this class might be made public
+  in the future (`#754 <https://github.com/omni-us/jsonargparse/pull/754>`__).
 
 
 v4.40.2 (2025-08-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,15 @@ Changed
 ^^^^^^^
 - Removed support for python 3.8 (`#752
   <https://github.com/omni-us/jsonargparse/pull/752>`__).
+- ``YAML`` comments feature is now implemented in a separate class to allow
+  better support for custom help formatters without breaking the comments (`#754
+  <https://github.com/omni-us/jsonargparse/pull/754>`__).
+
+Deprecated
+^^^^^^^^^^
+- ``DefaultHelpFormatter.*_yaml*_comment*`` methods are deprecated and will be
+  removed in v5.0.0. Instead use the new class ``YAMLCommentFormatter`` (`#754
+  <https://github.com/omni-us/jsonargparse/pull/754>`__).
 
 
 v4.40.2 (2025-08-06)

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from ._common import Action, is_subclass, parser_context
 from ._loaders_dumpers import get_loader_exceptions, load_value
 from ._namespace import Namespace, NSKeyError, split_key, split_key_root
-from ._optionals import _get_config_read_mode
+from ._optionals import _get_config_read_mode, ruyaml_support
 from ._type_checking import ActionsContainer, ArgumentParser
 from ._util import (
     Path,
@@ -251,13 +251,16 @@ class _ActionPrintConfig(Action):
             help=(
                 "Print the configuration after applying all other arguments and exit. The optional "
                 "flags customizes the output and are one or more keywords separated by comma. The "
-                "supported flags are: comments, skip_default, skip_null."
-            ),
+                "supported flags are:%s skip_default, skip_null."
+            )
+            % (" comments," if ruyaml_support else ""),
         )
 
     def __call__(self, parser, namespace, value, option_string=None):
         kwargs = {"subparser": parser, "key": None, "skip_none": False, "skip_validation": False}
-        valid_flags = {"": None, "comments": "yaml_comments", "skip_default": "skip_default", "skip_null": "skip_none"}
+        valid_flags = {"": None, "skip_default": "skip_default", "skip_null": "skip_none"}
+        if ruyaml_support:
+            valid_flags["comments"] = "yaml_comments"
         if value is not None:
             flags = value[0].split(",")
             invalid_flags = [f for f in flags if f not in valid_flags]

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -710,22 +710,12 @@ class HelpFormatterDeprecations:
         super().__init__(*args, **kwargs)
         self._yaml_formatter = YAMLCommentFormatter(self)
 
-    @deprecated(
-        """
-        The add_yaml_comments method is deprecated and will be removed in v5.0.0.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
+    @deprecated("The add_yaml_comments method is deprecated and will be removed in v5.0.0.")
     def add_yaml_comments(self, cfg: str) -> str:
         """Adds help text as yaml comments."""
         return self._yaml_formatter.add_yaml_comments(cfg)
 
-    @deprecated(
-        """
-        The set_yaml_start_comment method is deprecated and will be removed in v5.0.0.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
+    @deprecated("The set_yaml_start_comment method is deprecated and will be removed in v5.0.0.")
     def set_yaml_start_comment(self, text: str, cfg: ruyamlCommentedMap):
         """Sets the start comment to a ruyaml object.
 
@@ -735,12 +725,7 @@ class HelpFormatterDeprecations:
         """
         self._yaml_formatter.set_yaml_start_comment(text, cfg)
 
-    @deprecated(
-        """
-        The set_yaml_group_comment method is deprecated and will be removed in v5.0.0.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
+    @deprecated("The set_yaml_group_comment method is deprecated and will be removed in v5.0.0.")
     def set_yaml_group_comment(self, text: str, cfg: ruyamlCommentedMap, key: str, depth: int):
         """Sets the comment for a group to a ruyaml object.
 
@@ -752,12 +737,7 @@ class HelpFormatterDeprecations:
         """
         self._yaml_formatter.set_yaml_group_comment(text, cfg, key, depth)
 
-    @deprecated(
-        """
-        The set_yaml_argument_comment method is deprecated and will be removed in v5.0.0.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
+    @deprecated("The set_yaml_argument_comment method is deprecated and will be removed in v5.0.0.")
     def set_yaml_argument_comment(self, text: str, cfg: ruyamlCommentedMap, key: str, depth: int):
         """Sets the comment for an argument to a ruyaml object.
 

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, Optional, Set
 from ._common import Action, null_logger
 from ._common import LoggerProperty as InternalLoggerProperty
 from ._namespace import Namespace
-from ._type_checking import ArgumentParser
+from ._type_checking import ArgumentParser, ruyamlCommentedMap
 
 __all__ = [
     "ActionEnum",
@@ -701,3 +701,70 @@ class LoggerProperty(InternalLoggerProperty):
 def namespace_to_dict(namespace: Namespace) -> Dict[str, Any]:
     """Returns a copy of a nested namespace converted into a nested dictionary."""
     return namespace.clone().as_dict()
+
+
+class HelpFormatterDeprecations:
+    def __init__(self, *args, **kwargs):
+        from jsonargparse._formatters import YAMLCommentFormatter
+
+        super().__init__(*args, **kwargs)
+        self._yaml_formatter = YAMLCommentFormatter(self)
+
+    @deprecated(
+        """
+        The add_yaml_comments method is deprecated and will be removed in v5.0.0.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def add_yaml_comments(self, cfg: str) -> str:
+        """Adds help text as yaml comments."""
+        return self._yaml_formatter.add_yaml_comments(cfg)
+
+    @deprecated(
+        """
+        The set_yaml_start_comment method is deprecated and will be removed in v5.0.0.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_start_comment(self, text: str, cfg: ruyamlCommentedMap):
+        """Sets the start comment to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The ruyaml object.
+        """
+        self._yaml_formatter.set_yaml_start_comment(text, cfg)
+
+    @deprecated(
+        """
+        The set_yaml_group_comment method is deprecated and will be removed in v5.0.0.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_group_comment(self, text: str, cfg: ruyamlCommentedMap, key: str, depth: int):
+        """Sets the comment for a group to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the group.
+            depth: The nested level of the group.
+        """
+        self._yaml_formatter.set_yaml_group_comment(text, cfg, key, depth)
+
+    @deprecated(
+        """
+        The set_yaml_argument_comment method is deprecated and will be removed in v5.0.0.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_argument_comment(self, text: str, cfg: ruyamlCommentedMap, key: str, depth: int):
+        """Sets the comment for an argument to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the argument.
+            depth: The nested level of the argument.
+        """
+        self._yaml_formatter.set_yaml_argument_comment(text, cfg, key, depth)

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -30,7 +30,7 @@ from ._common import (
     supports_optionals_as_positionals,
 )
 from ._completions import ShtabAction
-from ._deprecated import deprecated
+from ._deprecated import HelpFormatterDeprecations
 from ._link_arguments import ActionLink
 from ._namespace import Namespace, NSKeyError
 from ._optionals import import_ruyaml
@@ -119,7 +119,7 @@ class YAMLCommentFormatter:
     def set_yaml_start_comment(
         self,
         text: str,
-        cfg: "ruyamlCommentedMap",
+        cfg: ruyamlCommentedMap,
     ):
         """Sets the start comment to a ruyaml object.
 
@@ -132,7 +132,7 @@ class YAMLCommentFormatter:
     def set_yaml_group_comment(
         self,
         text: str,
-        cfg: "ruyamlCommentedMap",
+        cfg: ruyamlCommentedMap,
         key: str,
         depth: int,
     ):
@@ -149,7 +149,7 @@ class YAMLCommentFormatter:
     def set_yaml_argument_comment(
         self,
         text: str,
-        cfg: "ruyamlCommentedMap",
+        cfg: ruyamlCommentedMap,
         key: str,
         depth: int,
     ):
@@ -164,7 +164,7 @@ class YAMLCommentFormatter:
         cfg.yaml_set_comment_before_after_key(key, before="\n" + text, indent=2 * depth)
 
 
-class DefaultHelpFormatter(HelpFormatter):
+class DefaultHelpFormatter(HelpFormatterDeprecations, HelpFormatter):
     """Help message formatter that includes types, default values and env var names.
 
     This class is an extension of `argparse.HelpFormatter
@@ -173,69 +173,6 @@ class DefaultHelpFormatter(HelpFormatter):
     with ``default_env=True`` command line options are preceded by 'ARG:' and
     the respective environment variable name is included preceded by 'ENV:'.
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._yaml_formatter = YAMLCommentFormatter(self)
-
-    @deprecated(
-        """
-        The add_yaml_comments method is deprecated and will be removed in a future version.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
-    def add_yaml_comments(self, cfg: str) -> str:
-        """Adds help text as yaml comments."""
-        return self._yaml_formatter.add_yaml_comments(cfg)
-
-    @deprecated(
-        """
-        The set_yaml_start_comment method is deprecated and will be removed in a future version.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
-    def set_yaml_start_comment(self, text: str, cfg: "ruyamlCommentedMap"):
-        """Sets the start comment to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The ruyaml object.
-        """
-        self._yaml_formatter.set_yaml_start_comment(text, cfg)
-
-    @deprecated(
-        """
-        The set_yaml_group_comment method is deprecated and will be removed in a future version.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
-    def set_yaml_group_comment(self, text: str, cfg: "ruyamlCommentedMap", key: str, depth: int):
-        """Sets the comment for a group to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The parent ruyaml object.
-            key: The key of the group.
-            depth: The nested level of the group.
-        """
-        self._yaml_formatter.set_yaml_group_comment(text, cfg, key, depth)
-
-    @deprecated(
-        """
-        The set_yaml_argument_comment method is deprecated and will be removed in a future version.
-        Use :class:`YAMLCommentFormatter` instead.
-    """
-    )
-    def set_yaml_argument_comment(self, text: str, cfg: "ruyamlCommentedMap", key: str, depth: int):
-        """Sets the comment for an argument to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The parent ruyaml object.
-            key: The key of the argument.
-            depth: The nested level of the argument.
-        """
-        self._yaml_formatter.set_yaml_argument_comment(text, cfg, key, depth)
 
     def _get_help_string(self, action: Action) -> str:
         action_help = " " if action.help == empty_help else action.help

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -37,7 +37,7 @@ from ._optionals import import_ruyaml
 from ._type_checking import ArgumentParser, ruyamlCommentedMap
 from ._typehints import ActionTypeHint, type_to_str
 
-__all__ = ["DefaultHelpFormatter", "YAMLCommentFormatter"]
+__all__ = ["DefaultHelpFormatter"]
 
 
 empty_help: str = "_EMPTY_HELP_"

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -30,13 +30,14 @@ from ._common import (
     supports_optionals_as_positionals,
 )
 from ._completions import ShtabAction
+from ._deprecated import deprecated
 from ._link_arguments import ActionLink
 from ._namespace import Namespace, NSKeyError
 from ._optionals import import_ruyaml
 from ._type_checking import ArgumentParser, ruyamlCommentedMap
 from ._typehints import ActionTypeHint, type_to_str
 
-__all__ = ["DefaultHelpFormatter"]
+__all__ = ["DefaultHelpFormatter", "YAMLCommentFormatter"]
 
 
 empty_help: str = "_EMPTY_HELP_"
@@ -54,6 +55,115 @@ class PercentTemplate(Template):
     """  # type: ignore[assignment]
 
 
+class YAMLCommentFormatter:
+    """Formatter class for adding YAML comments to configuration files."""
+
+    def __init__(self, help_formatter: HelpFormatter):
+        self.help_formatter = help_formatter
+
+    def add_yaml_comments(self, cfg: str) -> str:
+        """Adds help text as yaml comments."""
+        ruyaml = import_ruyaml("add_yaml_comments")
+        yaml = ruyaml.YAML()
+        cfg = yaml.load(cfg)
+
+        def get_subparsers(parser, prefix=""):
+            subparsers = {}
+            if parser._subparsers is not None:
+                for key, subparser in parser._subparsers._group_actions[0].choices.items():
+                    full_key = (prefix + "." if prefix else "") + key
+                    subparsers[full_key] = subparser
+                    subparsers.update(get_subparsers(subparser, prefix=full_key))
+            return subparsers
+
+        parser = parent_parser.get()
+        parsers = get_subparsers(parser)
+        parsers[None] = parser
+
+        group_titles = {}
+        for parser_key, parser in parsers.items():
+            group_titles[parser_key] = parser.description
+            prefix = "" if parser_key is None else parser_key + "."
+            for group in parser._action_groups:
+                actions = filter_default_actions(group._group_actions)
+                actions = [
+                    a for a in actions if not isinstance(a, (_ActionConfigLoad, ActionConfigFile, _ActionSubCommands))
+                ]
+                keys = {re.sub(r"\.?[^.]+$", "", a.dest) for a in actions if "." in a.dest}
+                for key in keys:
+                    group_titles[prefix + key] = group.title
+
+        def set_comments(cfg, prefix="", depth=0):
+            for key in cfg.keys():
+                full_key = (prefix + "." if prefix else "") + key
+                action = _find_action(parser, full_key)
+                text = None
+                if full_key in group_titles and isinstance(cfg[key], dict):
+                    text = group_titles[full_key]
+                elif action is not None and action.help not in {None, SUPPRESS}:
+                    text = self.help_formatter._expand_help(action)
+                if isinstance(cfg[key], dict):
+                    if text:
+                        self.set_yaml_group_comment(text, cfg, key, depth)
+                    set_comments(cfg[key], full_key, depth + 1)
+                elif text:
+                    self.set_yaml_argument_comment(text, cfg, key, depth)
+
+        if parser.description is not None:
+            self.set_yaml_start_comment(parser.description, cfg)
+        set_comments(cfg)
+        out = StringIO()
+        yaml.dump(cfg, out)
+        return out.getvalue()
+
+    def set_yaml_start_comment(
+        self,
+        text: str,
+        cfg: "ruyamlCommentedMap",
+    ):
+        """Sets the start comment to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The ruyaml object.
+        """
+        cfg.yaml_set_start_comment(text)
+
+    def set_yaml_group_comment(
+        self,
+        text: str,
+        cfg: "ruyamlCommentedMap",
+        key: str,
+        depth: int,
+    ):
+        """Sets the comment for a group to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the group.
+            depth: The nested level of the group.
+        """
+        cfg.yaml_set_comment_before_after_key(key, before="\n" + text, indent=2 * depth)
+
+    def set_yaml_argument_comment(
+        self,
+        text: str,
+        cfg: "ruyamlCommentedMap",
+        key: str,
+        depth: int,
+    ):
+        """Sets the comment for an argument to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the argument.
+            depth: The nested level of the argument.
+        """
+        cfg.yaml_set_comment_before_after_key(key, before="\n" + text, indent=2 * depth)
+
+
 class DefaultHelpFormatter(HelpFormatter):
     """Help message formatter that includes types, default values and env var names.
 
@@ -63,6 +173,69 @@ class DefaultHelpFormatter(HelpFormatter):
     with ``default_env=True`` command line options are preceded by 'ARG:' and
     the respective environment variable name is included preceded by 'ENV:'.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._yaml_formatter = YAMLCommentFormatter(self)
+
+    @deprecated(
+        """
+        The add_yaml_comments method is deprecated and will be removed in a future version.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def add_yaml_comments(self, cfg: str) -> str:
+        """Adds help text as yaml comments."""
+        return self._yaml_formatter.add_yaml_comments(cfg)
+
+    @deprecated(
+        """
+        The set_yaml_start_comment method is deprecated and will be removed in a future version.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_start_comment(self, text: str, cfg: "ruyamlCommentedMap"):
+        """Sets the start comment to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The ruyaml object.
+        """
+        self._yaml_formatter.set_yaml_start_comment(text, cfg)
+
+    @deprecated(
+        """
+        The set_yaml_group_comment method is deprecated and will be removed in a future version.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_group_comment(self, text: str, cfg: "ruyamlCommentedMap", key: str, depth: int):
+        """Sets the comment for a group to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the group.
+            depth: The nested level of the group.
+        """
+        self._yaml_formatter.set_yaml_group_comment(text, cfg, key, depth)
+
+    @deprecated(
+        """
+        The set_yaml_argument_comment method is deprecated and will be removed in a future version.
+        Use :class:`YAMLCommentFormatter` instead.
+    """
+    )
+    def set_yaml_argument_comment(self, text: str, cfg: "ruyamlCommentedMap", key: str, depth: int):
+        """Sets the comment for an argument to a ruyaml object.
+
+        Args:
+            text: The content to use for the comment.
+            cfg: The parent ruyaml object.
+            key: The key of the argument.
+            depth: The nested level of the argument.
+        """
+        self._yaml_formatter.set_yaml_argument_comment(text, cfg, key, depth)
 
     def _get_help_string(self, action: Action) -> str:
         action_help = " " if action.help == empty_help else action.help
@@ -183,108 +356,6 @@ class DefaultHelpFormatter(HelpFormatter):
     def add_usage(self, usage: Optional[str], actions: Iterable[Action], *args, **kwargs) -> None:
         actions = [a for a in actions if not isinstance(a, ActionLink)]
         super().add_usage(usage, actions, *args, **kwargs)
-
-    def add_yaml_comments(self, cfg: str) -> str:
-        """Adds help text as yaml comments."""
-        ruyaml = import_ruyaml("add_yaml_comments")
-        yaml = ruyaml.YAML()
-        cfg = yaml.load(cfg)
-
-        def get_subparsers(parser, prefix=""):
-            subparsers = {}
-            if parser._subparsers is not None:
-                for key, subparser in parser._subparsers._group_actions[0].choices.items():
-                    full_key = (prefix + "." if prefix else "") + key
-                    subparsers[full_key] = subparser
-                    subparsers.update(get_subparsers(subparser, prefix=full_key))
-            return subparsers
-
-        parser = parent_parser.get()
-        parsers = get_subparsers(parser)
-        parsers[None] = parser
-
-        group_titles = {}
-        for parser_key, parser in parsers.items():
-            group_titles[parser_key] = parser.description
-            prefix = "" if parser_key is None else parser_key + "."
-            for group in parser._action_groups:
-                actions = filter_default_actions(group._group_actions)
-                actions = [
-                    a for a in actions if not isinstance(a, (_ActionConfigLoad, ActionConfigFile, _ActionSubCommands))
-                ]
-                keys = {re.sub(r"\.?[^.]+$", "", a.dest) for a in actions if "." in a.dest}
-                for key in keys:
-                    group_titles[prefix + key] = group.title
-
-        def set_comments(cfg, prefix="", depth=0):
-            for key in cfg.keys():
-                full_key = (prefix + "." if prefix else "") + key
-                action = _find_action(parser, full_key)
-                text = None
-                if full_key in group_titles and isinstance(cfg[key], dict):
-                    text = group_titles[full_key]
-                elif action is not None and action.help not in {None, SUPPRESS}:
-                    text = self._expand_help(action)
-                if isinstance(cfg[key], dict):
-                    if text:
-                        self.set_yaml_group_comment(text, cfg, key, depth)
-                    set_comments(cfg[key], full_key, depth + 1)
-                elif text:
-                    self.set_yaml_argument_comment(text, cfg, key, depth)
-
-        if parser.description is not None:
-            self.set_yaml_start_comment(parser.description, cfg)
-        set_comments(cfg)
-        out = StringIO()
-        yaml.dump(cfg, out)
-        return out.getvalue()
-
-    def set_yaml_start_comment(
-        self,
-        text: str,
-        cfg: ruyamlCommentedMap,
-    ):
-        """Sets the start comment to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The ruyaml object.
-        """
-        cfg.yaml_set_start_comment(text)
-
-    def set_yaml_group_comment(
-        self,
-        text: str,
-        cfg: ruyamlCommentedMap,
-        key: str,
-        depth: int,
-    ):
-        """Sets the comment for a group to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The parent ruyaml object.
-            key: The key of the group.
-            depth: The nested level of the group.
-        """
-        cfg.yaml_set_comment_before_after_key(key, before="\n" + text, indent=2 * depth)
-
-    def set_yaml_argument_comment(
-        self,
-        text: str,
-        cfg: ruyamlCommentedMap,
-        key: str,
-        depth: int,
-    ):
-        """Sets the comment for an argument to a ruyaml object.
-
-        Args:
-            text: The content to use for the comment.
-            cfg: The parent ruyaml object.
-            key: The key of the argument.
-            depth: The nested level of the argument.
-        """
-        cfg.yaml_set_comment_before_after_key(key, before="\n" + text, indent=2 * depth)
 
 
 def get_env_var(

--- a/jsonargparse/_loaders_dumpers.py
+++ b/jsonargparse/_loaders_dumpers.py
@@ -2,11 +2,19 @@
 
 import inspect
 import re
+from argparse import HelpFormatter
 from contextlib import suppress
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Type
 
 from ._common import load_value_mode, parent_parser
-from ._optionals import import_jsonnet, import_toml_dumps, import_toml_loads, omegaconf_support, pyyaml_available
+from ._optionals import (
+    import_jsonnet,
+    import_toml_dumps,
+    import_toml_loads,
+    omegaconf_support,
+    pyyaml_available,
+    ruyaml_support,
+)
 from ._type_checking import ArgumentParser
 
 __all__ = [
@@ -249,13 +257,14 @@ def toml_dump(data):
 
 dumpers: Dict[str, Callable] = {
     "yaml": yaml_dump,
-    "yaml_comments": yaml_comments_dump,
     "json": json_compact_dump,
     "json_compact": json_compact_dump,
     "json_indented": json_indented_dump,
     "toml": toml_dump,
     "jsonnet": json_indented_dump,
 }
+if ruyaml_support:
+    dumpers["yaml_comments"] = yaml_comments_dump
 
 comment_prefix: Dict[str, str] = {
     "yaml": "# ",
@@ -336,7 +345,7 @@ def set_omegaconf_loader():
 set_loader("jsonnet", jsonnet_load, get_loader_exceptions("jsonnet"))
 
 
-def create_help_formatter_with_comments(formatter_class: Type["HelpFormatter"]) -> Type["HelpFormatter"]:
+def create_help_formatter_with_comments(formatter_class: Type[HelpFormatter]) -> Type[HelpFormatter]:
     """Creates a dynamic class that combines a formatter with YAML comment functionality.
 
     Args:
@@ -347,7 +356,7 @@ def create_help_formatter_with_comments(formatter_class: Type["HelpFormatter"]) 
     """
     from ._formatters import YAMLCommentFormatter
 
-    class DynamicHelpFormatter(formatter_class):
+    class DynamicHelpFormatter(formatter_class):  # type: ignore[valid-type,misc]
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self._yaml_formatter = YAMLCommentFormatter(self)

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -761,10 +761,20 @@ def test_print_config_skip_null(print_parser):
 @pytest.mark.skipif(not ruyaml_support, reason="ruyaml package is required")
 @skip_if_docstring_parser_unavailable
 def test_print_config_comments(print_parser):
+    help_str = get_parser_help(print_parser)
+    assert "comments," in help_str
     out = get_parse_args_stdout(print_parser, ["--print_config=comments"])
     assert "# cli tool" in out
     assert "# Option v1. (default: 1)" in out
     assert "# Option v2. (default: 2)" in out
+
+
+@pytest.mark.skipif(ruyaml_support, reason="ruyaml package should not be installed")
+def test_print_config_comments_unavailable(print_parser):
+    help_str = get_parser_help(print_parser)
+    assert "comments," not in help_str
+    with pytest.raises(ArgumentError, match='Invalid option "comments"'):
+        get_parse_args_stdout(print_parser, ["--print_config=comments"])
 
 
 def test_print_config_invalid_flag(print_parser):

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -745,23 +745,19 @@ def test_DefaultHelpFormatter_yaml_comments(parser):
     with catch_warnings(record=True) as w:
         formatter.add_yaml_comments("arg: 1")
     assert "add_yaml_comments method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
-    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.add_yaml_comments(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_start_comment("start", cfg)
     assert "set_yaml_start_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
-    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_start_comment(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_group_comment("group", cfg, "arg", 0)
     assert "set_yaml_group_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
-    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_group_comment(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_argument_comment("arg", cfg, "arg", 0)
     assert "set_yaml_argument_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
-    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_argument_comment(" in source[w[-1].lineno - 1]

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -44,6 +44,7 @@ from jsonargparse._optionals import (
     import_ruyaml,
     jsonnet_support,
     pyyaml_available,
+    ruyaml_support,
     url_support,
 )
 from jsonargparse._util import argument_error
@@ -730,8 +731,8 @@ def test_namespace_to_dict():
     )
 
 
-def test_DefaultHelpFormatter_yaml_comments():
-    parser = ArgumentParser()
+@pytest.mark.skipif(not ruyaml_support, reason="ruyaml package is required")
+def test_DefaultHelpFormatter_yaml_comments(parser):
     parser.add_argument("--arg", type=int, help="Description")
     formatter = DefaultHelpFormatter(prog="test")
     from jsonargparse._common import parent_parser
@@ -743,32 +744,24 @@ def test_DefaultHelpFormatter_yaml_comments():
 
     with catch_warnings(record=True) as w:
         formatter.add_yaml_comments("arg: 1")
-    assert "The add_yaml_comments method is deprecated and will be removed in a future version. Use" in str(
-        w[-1].message
-    )
-    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "add_yaml_comments method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
+    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.add_yaml_comments(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_start_comment("start", cfg)
-    assert "The set_yaml_start_comment method is deprecated and will be removed in a future version. Use" in str(
-        w[-1].message
-    )
-    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "set_yaml_start_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
+    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_start_comment(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_group_comment("group", cfg, "arg", 0)
-    assert "The set_yaml_group_comment method is deprecated and will be removed in a future version. Use" in str(
-        w[-1].message
-    )
-    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "set_yaml_group_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
+    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_group_comment(" in source[w[-1].lineno - 1]
 
     with catch_warnings(record=True) as w:
         formatter.set_yaml_argument_comment("arg", cfg, "arg", 0)
-    assert "The set_yaml_argument_comment method is deprecated and will be removed in a future version. Use" in str(
-        w[-1].message
-    )
-    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "set_yaml_argument_comment method is deprecated and will be removed in v5.0.0" in str(w[-1].message)
+    assert ":class:`YAMLCommentFormatter`" in str(w[-1].message)
     assert "formatter.set_yaml_argument_comment(" in source[w[-1].lineno - 1]

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -37,9 +37,11 @@ from jsonargparse._deprecated import (
     shown_deprecation_warnings,
     usage_and_exit_error_handler,
 )
+from jsonargparse._formatters import DefaultHelpFormatter
 from jsonargparse._optionals import (
     docstring_parser_support,
     get_docstring_parse_options,
+    import_ruyaml,
     jsonnet_support,
     pyyaml_available,
     url_support,
@@ -726,3 +728,47 @@ def test_namespace_to_dict():
         message="namespace_to_dict was deprecated",
         code="dic1 = namespace_to_dict(ns)",
     )
+
+
+def test_DefaultHelpFormatter_yaml_comments():
+    parser = ArgumentParser()
+    parser.add_argument("--arg", type=int, help="Description")
+    formatter = DefaultHelpFormatter(prog="test")
+    from jsonargparse._common import parent_parser
+
+    parent_parser.set(parser)
+    ruyaml = import_ruyaml("test_DefaultHelpFormatter_yaml_comments")
+    yaml = ruyaml.YAML()
+    cfg = yaml.load("arg: 1")
+
+    with catch_warnings(record=True) as w:
+        formatter.add_yaml_comments("arg: 1")
+    assert "The add_yaml_comments method is deprecated and will be removed in a future version. Use" in str(
+        w[-1].message
+    )
+    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "formatter.add_yaml_comments(" in source[w[-1].lineno - 1]
+
+    with catch_warnings(record=True) as w:
+        formatter.set_yaml_start_comment("start", cfg)
+    assert "The set_yaml_start_comment method is deprecated and will be removed in a future version. Use" in str(
+        w[-1].message
+    )
+    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "formatter.set_yaml_start_comment(" in source[w[-1].lineno - 1]
+
+    with catch_warnings(record=True) as w:
+        formatter.set_yaml_group_comment("group", cfg, "arg", 0)
+    assert "The set_yaml_group_comment method is deprecated and will be removed in a future version. Use" in str(
+        w[-1].message
+    )
+    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "formatter.set_yaml_group_comment(" in source[w[-1].lineno - 1]
+
+    with catch_warnings(record=True) as w:
+        formatter.set_yaml_argument_comment("arg", cfg, "arg", 0)
+    assert "The set_yaml_argument_comment method is deprecated and will be removed in a future version. Use" in str(
+        w[-1].message
+    )
+    assert ":class:`YAMLCommentFormatter` instead" in str(w[-1].message)
+    assert "formatter.set_yaml_argument_comment(" in source[w[-1].lineno - 1]


### PR DESCRIPTION
## What does this PR do?

Refactoring to allow in the future better support for custom help formatters without breaking the comments feature.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** with the pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
