### PR TITLE
Fix environment variable names not shown in help for positional arguments when default_env is true

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/756>`__).
 - Some deprecations not shown in the API documentation (`#760
   <https://github.com/omni-us/jsonargparse/pull/760>`__).
+- Environment variable names not shown in help for positional arguments when
+  ``default_env`` is true (`#763
+  <https://github.com/omni-us/jsonargparse/pull/763>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -247,7 +247,7 @@ class DefaultHelpFormatter(HelpFormatterDeprecations, HelpFormatter):
             if parser.default_env:
                 value = f"ENV:   {get_env_var(self, action)}\n\n  {value}"
             return value
-        if action.option_strings == [] or not parser.default_env:
+        if not parser.default_env:
             return super()._format_action_invocation(action)
         extr = ""
         if not isinstance(action, (_ActionHelpClassPath, _ActionPrintConfig, ShtabAction, _HelpAction)):

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -228,6 +228,15 @@ def test_parse_env_config(parser):
     pytest.raises(ArgumentError, lambda: parser.parse_env({"APP_CFG": '{"undefined": True}'}))
 
 
+def test_parse_env_positional():
+    parser = ArgumentParser(prog="app", exit_on_error=False, default_env=True)
+    parser.add_argument("pos", type=int)
+    with patch.dict(os.environ, {"APP_POS": "1"}):
+        assert parser.parse_env() == Namespace(pos=1)
+    with pytest.raises(ArgumentError, match="Got value: 1.1"):
+        parser.parse_env({"APP_POS": "1.1"})
+
+
 def test_parse_env_positional_nargs_plus(parser):
     parser.env_prefix = "app"
     parser.add_argument("req", nargs="+")

--- a/jsonargparse_tests/test_formatters.py
+++ b/jsonargparse_tests/test_formatters.py
@@ -32,6 +32,13 @@ def test_help_action_config_file(parser):
     assert "APP_PRINT_CONFIG" not in help_str
 
 
+def test_help_positional(parser):
+    parser.add_argument("pos")
+    help_str = get_parser_help(parser)
+    assert "ARG:   pos" in help_str
+    assert "ENV:   APP_POS" in help_str
+
+
 def test_help_required_and_default(parser):
     parser.add_argument("--v1", help="Option v1.", default="v1", required=True)
     help_str = get_parser_help(parser)


### PR DESCRIPTION
## What does this PR do?

Fixes bug mentioned in https://github.com/omni-us/jsonargparse/issues/680#issuecomment-2673761804

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
