### PR TITLE
Fix dataclass with default failing when validate_defaults=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Fixed
 ^^^^^
 - Stubs resolver in some cases failing with maximum recursion error (`#770
   <https://github.com/omni-us/jsonargparse/pull/770>`__).
+- ``dataclass`` with default failing when ``validate_defaults=True`` (`#771
+  <https://github.com/omni-us/jsonargparse/pull/771>`__).
 
 
 v4.41.0 (2025-09-04)

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -171,6 +171,10 @@ def validate_default(container: ActionsContainer, action: argparse.Action):
     if action.default is None or not get_parsing_setting("validate_defaults") or not hasattr(action, "_check_type"):
         return
     try:
+        from ._core import ArgumentGroup
+
+        if isinstance(container, ArgumentGroup):
+            container = container.parser  # type: ignore[assignment]
         with parser_context(parent_parser=container):
             default = action.default
             action.default = None

--- a/jsonargparse_tests/test_parsing_settings.py
+++ b/jsonargparse_tests/test_parsing_settings.py
@@ -45,6 +45,18 @@ def test_validate_defaults_failure(parser):
         parser.add_argument("--num", type=int, default="x")
 
 
+@dataclass
+class DataWithDefault:
+    param: str = "foo"
+
+
+def test_validate_defaults_dataclass(parser):
+    set_parsing_settings(validate_defaults=True)
+
+    added_args = parser.add_class_arguments(DataWithDefault)
+    assert added_args == ["param"]
+
+
 # parse_optionals_as_positionals
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/omni-us/jsonargparse/issues/237#issuecomment-3270692850

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
