### PR TITLE
Fix omegaconf+ parser mode failing when there are inf, -inf or nan values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/771>`__).
 - Misleading error message when a namespace is used in a list comprehension
   (`#772 <https://github.com/omni-us/jsonargparse/pull/772>`__).
+- ``omegaconf+`` parser mode failing when there are ``inf``, ``-inf`` or ``nan``
+  values (`#773 <https://github.com/omni-us/jsonargparse/pull/773>`__).
 
 
 v4.41.0 (2025-09-04)

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -296,9 +296,7 @@ def omegaconf_apply(parser, cfg):
     from ._common import parser_context
 
     with parser_context(path_dump_preserve_relative=True):
-        cfg_dict = parser.dump(
-            cfg, format="json_compact", skip_validation=True, skip_none=False, skip_link_targets=False
-        )
+        cfg_dict = parser.dump(cfg, skip_validation=True, skip_none=False, skip_link_targets=False)
     cfg_omegaconf = OmegaConf.create(cfg_dict)
     cfg_dict = OmegaConf.to_container(cfg_omegaconf, resolve=True)
     return parser._apply_actions(cfg_dict)

--- a/jsonargparse_tests/test_omegaconf.py
+++ b/jsonargparse_tests/test_omegaconf.py
@@ -176,3 +176,20 @@ def test_omegaconf_global_path_preserve_relative(parser, tmp_cwd):
     with parser_context(path_dump_preserve_relative=True):
         dump = yaml.safe_load(parser.dump(cfg))["nested"]["path"]
     assert dump == {"relative": "file", "cwd": str(tmp_cwd / subdir)}
+
+
+@skip_if_omegaconf_unavailable
+def test_omegaconf_inf_nan(parser):
+    parser.parser_mode = "omegaconf+"
+    parser.add_argument("--a", type=float, default=0.0)
+    parser.add_argument("--b", type=float, default=1.0)
+    parser.add_argument("--c", type=float, default=float("nan"))
+    parser.add_argument("--d", type=float, default=float("inf"))
+    parser.add_argument("--e", type=float, default=float("-inf"))
+
+    cfg = parser.parse_args(["--a=2.5", "--b=${a}"])
+    assert cfg.a == 2.5
+    assert cfg.b == 2.5
+    assert math.isnan(cfg.c)
+    assert cfg.d == float("inf")
+    assert cfg.e == float("-inf")


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/omni-us/jsonargparse/pull/765#discussion_r2333327082

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
