### PR TITLE
New omegaconf_absolute_to_relative_paths parsing setting to enable backward compatibility of omegaconf+ parser mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Added
 - ``set_parsing_settings`` now supports setting ``allow_py_files`` to enable
   stubs resolver searching in ``.py`` files in addition to ``.pyi`` (`#770
   <https://github.com/omni-us/jsonargparse/pull/770>`__).
+- ``set_parsing_settings`` now supports ``omegaconf_absolute_to_relative_paths``
+  to enable backward compatibility of ``omegaconf+`` parser mode by converting
+  absolute paths to relative in interpolations (`#774
+  <https://github.com/omni-us/jsonargparse/pull/774>`__).
 
 Fixed
 ^^^^^

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -2475,7 +2475,10 @@ limitations of the ``omegaconf`` mode mentioned earlier. Instead of applying
 OmegaConf resolvers to each YAML config individually, the resolving is performed
 once at the end of the parsing process. As a result, in nested sub-configs,
 references to nodes must be either relative or parser-level absolute to function
-correctly.
+correctly. Alternatively, you can
+``set_parsing_settings(omegaconf_absolute_to_relative_paths=True)`` to enable
+automatic conversion of absolute paths to relative ones during parsing. However,
+this automatic conversion does not work for every possible case.
 
 Based on community feedback, this mode may become the default ``omegaconf`` mode
 in version 5.0.0. This change would introduce a breaking modification, as

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -97,6 +97,7 @@ parsing_settings = {
     "validate_defaults": False,
     "parse_optionals_as_positionals": False,
     "stubs_resolver_allow_py_files": False,
+    "omegaconf_absolute_to_relative_paths": False,
 }
 
 
@@ -109,6 +110,7 @@ def set_parsing_settings(
     docstring_parse_attribute_docstrings: Optional[bool] = None,
     parse_optionals_as_positionals: Optional[bool] = None,
     stubs_resolver_allow_py_files: Optional[bool] = None,
+    omegaconf_absolute_to_relative_paths: Optional[bool] = None,
 ) -> None:
     """
     Modify settings that affect the parsing behavior.
@@ -133,6 +135,10 @@ def set_parsing_settings(
             parser. By default, this is False.
         stubs_resolver_allow_py_files: Whether the stubs resolver should search
             in ``.py`` files in addition to ``.pyi`` files.
+        omegaconf_absolute_to_relative_paths: If True, when loading configs
+            with ``omegaconf+`` parser mode, absolute interpolation paths are
+            converted to relative. This is only intended for backward
+            compatibility with ``omegaconf`` parser mode.
     """
     # validate_defaults
     if isinstance(validate_defaults, bool):
@@ -159,6 +165,13 @@ def set_parsing_settings(
         parsing_settings["stubs_resolver_allow_py_files"] = stubs_resolver_allow_py_files
     elif stubs_resolver_allow_py_files is not None:
         raise ValueError(f"stubs_resolver_allow_py_files must be a boolean, but got {stubs_resolver_allow_py_files}.")
+    # omegaconf_absolute_to_relative_paths
+    if isinstance(omegaconf_absolute_to_relative_paths, bool):
+        parsing_settings["omegaconf_absolute_to_relative_paths"] = omegaconf_absolute_to_relative_paths
+    elif omegaconf_absolute_to_relative_paths is not None:
+        raise ValueError(
+            f"omegaconf_absolute_to_relative_paths must be a boolean, but got {omegaconf_absolute_to_relative_paths}."
+        )
 
 
 def get_parsing_setting(name: str):

--- a/jsonargparse/_loaders_dumpers.py
+++ b/jsonargparse/_loaders_dumpers.py
@@ -339,7 +339,7 @@ def set_omegaconf_loader(mode="omegaconf"):
     if omegaconf_support and mode not in loaders:
         from ._optionals import get_omegaconf_loader
 
-        loader = yaml_load if mode == "omegaconf+" else get_omegaconf_loader()
+        loader = get_omegaconf_loader(mode)
         set_loader(mode, loader, get_loader_exceptions("yaml"))
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/omni-us/jsonargparse/pull/765#pullrequestreview-3201222691

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
