### PR TITLE
Fix misleading error message for invalid value for Literal strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/787>`__).
 - ``Union`` with path type and non-path value incorrectly dumped as string
   (`#789 <https://github.com/omni-us/jsonargparse/pull/789>`__).
+- Misleading error message for invalid value for ``Literal`` strings (`#790
+  <https://github.com/omni-us/jsonargparse/pull/790>`__).
 
 
 v4.42.0 (2025-10-14)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -781,8 +781,9 @@ def adapt_typehints(
     # Literal
     elif typehint_origin in literal_types:
         if val not in subtypehints and isinstance(val, str):
-            subtypes = Union[tuple((type(v) for v in subtypehints if type(v) is not str))]
-            val = adapt_typehints(val, subtypes, **adapt_kwargs)
+            subtypes = tuple((type(v) for v in subtypehints if type(v) is not str))
+            if subtypes:
+                val = adapt_typehints(val, Union[subtypes], **adapt_kwargs)
         if val not in subtypehints:
             raise_unexpected_value(f"Expected a {typehint}", val)
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -183,6 +183,8 @@ def test_union_of_literals(parser):
     parser.add_argument("--literal", type=Union[Literal[1, 2], Literal["a", "b"]])
     assert "a" == parser.parse_args(["--literal=a"]).literal
     assert 2 == parser.parse_args(["--literal=2"]).literal
+    with pytest.raises(ArgumentError, match=r"Expected a typing.Literal\['a', 'b']"):
+        parser.parse_args(["--literal=x"])
 
 
 @parser_modes


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
