### PR TITLE
Path.__call__ deprecation not shown in docs

### DIFF
--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -24,6 +24,7 @@ __all__ = [
     "ActionPathList",
     "HelpFormatterDeprecations",
     "LoggerProperty",
+    "PathDeprecations",
     "ParserDeprecations",
     "ParserError",
     "compose_dataclasses",
@@ -499,8 +500,8 @@ class PathDeprecations:
         deprecation_warning("Path attr set", path_immutable_attrs_message)
         self._skip_check = skip_check
 
+    @deprecated(path_call_message)
     def __call__(self, absolute: bool = True) -> str:
-        deprecation_warning("Path.__call__", path_call_message)
         return self._absolute if absolute else self._relative
 
 


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [n/a] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
