### PR TITLE
Fix changing omegaconf_absolute_to_relative_paths not taking effect after parsing once

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Fixed
   (`#789 <https://github.com/omni-us/jsonargparse/pull/789>`__).
 - Misleading error message for invalid value for ``Literal`` strings (`#790
   <https://github.com/omni-us/jsonargparse/pull/790>`__).
+- Changing ``omegaconf_absolute_to_relative_paths`` not taking effect after
+  parsing once (`#805 <https://github.com/omni-us/jsonargparse/pull/805>`__).
 
 Changed
 ^^^^^^^


### PR DESCRIPTION
## What does this PR do?

The actual fix was included in pull request #800. Here the corresponding unit test is added.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
