### PR TITLE
Union types with str and default comment-like string incorrectly parsed as a stringified exception of an other subtype

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ paths are considered internals and can change in minor and patch releases.
 v4.44.0 (unreleased)
 --------------------
 
+Fixed
+^^^^^
+- Union types with str and default comment-like string incorrectly parsed as a
+  stringified exception of an other subtype (`#812
+  <https://github.com/omni-us/jsonargparse/pull/812>`__).
+
 Changed
 ^^^^^^^
 - Improved error messages when not accepted options are given, referencing which

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -854,7 +854,7 @@ def adapt_typehints(
                 vals.append(ex)
         if all(isinstance(v, Exception) for v in vals):
             raise_union_unexpected_value(sorted_subtypes, val, vals)
-        val = vals[-1]
+        val = next((v for v in reversed(vals) if not isinstance(v, Exception)))
 
     # Tuple or Set
     elif typehint_origin in tuple_set_origin_types:

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -125,6 +125,12 @@ def test_str_edge_cases(parser):
     assert parser.parse_args([f"--val={val}"]).val == val
 
 
+def test_str_union_default_comment_like(parser):
+    parser.add_argument("--val", type=Union[str, int], default="#default")
+    assert "#default" == parser.get_defaults().val
+    assert "#default" == parser.parse_args([]).val
+
+
 def test_bool_parse(parser):
     parser.add_argument("--val", type=bool)
     assert None is parser.get_defaults().val


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/pytorch-lightning/pull/21340

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
