### PR TITLE
Fix getting parameter descriptions from docstrings for dataclass inheritance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Fixed
 - Evaluation of postponed annotations for dataclass inheritance across modules
   not working correctly (`#814
   <https://github.com/omni-us/jsonargparse/pull/814>`__).
+- Getting parameter descriptions from docstrings not working for dataclass
+  inheritance (`#815 <https://github.com/omni-us/jsonargparse/pull/815>`__).
 
 
 v4.44.0 (2025-11-25)

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -5,6 +5,7 @@ import os
 import re
 from contextlib import contextmanager
 from copy import deepcopy
+from dataclasses import is_dataclass
 from importlib.metadata import version
 from importlib.util import find_spec
 from typing import Optional, Union
@@ -242,6 +243,10 @@ def parse_docstring(component, params=False, logger=None):
 def parse_docs(component, parent, logger):
     docs = {}
     if docstring_parser_support:
+        if is_dataclass(parent) and component.__name__ == "__init__":
+            next_mro = inspect.getmro(parent)[1]
+            if is_dataclass(next_mro):
+                docs.update(parse_docs(next_mro, next_mro.__init__, logger))
         doc_sources = [component]
         if inspect.isclass(parent) and component.__name__ == "__init__":
             doc_sources += [parent]

--- a/jsonargparse_tests/test_dataclasses.py
+++ b/jsonargparse_tests/test_dataclasses.py
@@ -37,6 +37,12 @@ ListPositiveInt = List[PositiveInt]
 
 @dataclasses.dataclass
 class DifferentModuleBaseData:
+    """
+    Args:
+        count: between 3 and 9
+        numbers: list of positive ints
+    """
+
     count: Optional[BetweenThreeAndNine] = None  # type: ignore[valid-type]
     numbers: ListPositiveInt = dataclasses.field(default_factory=list)
 

--- a/jsonargparse_tests/test_postponed_annotations.py
+++ b/jsonargparse_tests/test_postponed_annotations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 import pytest
 
 from jsonargparse import Namespace
+from jsonargparse._optionals import docstring_parser_support
 from jsonargparse._parameter_resolvers import get_signature_parameters as get_params
 from jsonargparse._postponed_annotations import (
     TypeCheckingVisitor,
@@ -329,6 +330,11 @@ def test_add_dataclass_with_init_pep585(parser, tmp_cwd):
 
 @dataclasses.dataclass
 class InheritDifferentModule(DifferentModuleBaseData):
+    """
+    Args:
+        extra: an extra string
+    """
+
     extra: str = "default"
 
 
@@ -339,6 +345,8 @@ def test_get_params_dataclass_inherit_different_module():
     params = get_params(InheritDifferentModule)
 
     assert [p.name for p in params] == ["count", "numbers", "extra"]
+    if docstring_parser_support:
+        assert [p.doc for p in params] == ["between 3 and 9", "list of positive ints", "an extra string"]
     assert all(not isinstance(p.annotation, str) for p in params)
     assert not isinstance(params[0].annotation.__args__[0], str)
     assert "BetweenThreeAndNine" in str(params[0].annotation)


### PR DESCRIPTION
## What does this PR do?

https://github.com/omni-us/jsonargparse/issues/287#issuecomment-3583447960

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
