### PR TITLE
List of paths types improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,14 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
-v4.44.1 (unreleased)
+v4.45.0 (unreleased)
 --------------------
+
+Added
+^^^^^
+- Signature methods now when given ``sub_configs=True``, list of paths types can
+  now receive a file containing a list of paths (`#816
+  <https://github.com/omni-us/jsonargparse/pull/816>`__).
 
 Fixed
 ^^^^^
@@ -22,6 +28,12 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/814>`__).
 - Getting parameter descriptions from docstrings not working for dataclass
   inheritance (`#815 <https://github.com/omni-us/jsonargparse/pull/815>`__).
+
+Changed
+^^^^^^^
+- List of paths types now show in the help the supported options for providing
+  paths like ``'["PATH1",...]' | LIST_OF_PATHS_FILE | -`` (`#816
+  <https://github.com/omni-us/jsonargparse/pull/816>`__).
 
 
 v4.44.0 (2025-11-25)

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -24,6 +24,7 @@ from ._typehints import (
     LazyInitBaseClass,
     callable_instances,
     get_subclass_names,
+    is_list_pathlike,
     is_optional,
     not_required_types,
     sequence_origin_types,
@@ -419,7 +420,9 @@ class SignatureArguments(LoggerProperty):
                 else:
                     register_pydantic_type(annotation)
                 enable_path = sub_configs and (
-                    is_subclass_typehint or ActionTypeHint.is_return_subclass_typehint(annotation)
+                    is_subclass_typehint
+                    or ActionTypeHint.is_return_subclass_typehint(annotation)
+                    or is_list_pathlike(annotation)
                 )
                 args = ActionTypeHint.prepare_add_argument(
                     args=args,

--- a/jsonargparse_tests/test_dataclasses.py
+++ b/jsonargparse_tests/test_dataclasses.py
@@ -626,7 +626,7 @@ class UnionClass:
     ],
 )
 def test_class_path_union_mixture_dataclass_and_class(parser, union_type):
-    parser.add_argument("--union", type=union_type, enable_path=True)
+    parser.add_argument("--union", type=union_type)
 
     value = {"class_path": f"{__name__}.UnionData", "init_args": {"data_a": 2, "data_b": "x"}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])


### PR DESCRIPTION
## What does this PR do?

- Signature methods now when given `sub_configs=True`, list of paths types can now receive a file containing a list of paths.
- List of paths types now show in the help the supported options for providing paths.

Fixes #802

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
