### PR TITLE
Fix register_type not checking that the given type is a class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/818>`__).
 - ``default_config_files`` with settings for multiple subcommands not working
   correctly (`#819 <https://github.com/omni-us/jsonargparse/pull/819>`__).
+- ``register_type`` not checking that the given type is a class (`#820
+  <https://github.com/omni-us/jsonargparse/pull/820>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/typing.py
+++ b/jsonargparse/typing.py
@@ -309,7 +309,7 @@ class RegisteredType:
 
 
 def register_type(
-    type_class: Any,
+    type_class: type,
     serializer: Callable = str,
     deserializer: Optional[Callable] = None,
     deserializer_exceptions: Union[type[Exception], tuple[type[Exception], ...]] = (
@@ -324,7 +324,7 @@ def register_type(
     """Registers a new type for use in jsonargparse parsers.
 
     Args:
-        type_class: The type object to be registered.
+        type_class: The class to be registered.
         serializer: Function that converts an instance of the class to a basic type.
         deserializer: Function that converts a basic type to an instance of the class. Default instantiates type_class.
         deserializer_exceptions: Exceptions that deserializer raises when it fails.
@@ -332,6 +332,8 @@ def register_type(
         fail_already_registered: Whether to fail if type has already been registered.
         uniqueness_key: Key to determine uniqueness of type.
     """
+    if not inspect.isclass(type_class):
+        raise ValueError(f"Expected type_class to be a class, got {type_class!r}")
     type_handler = RegisteredType(type_class, serializer, deserializer, deserializer_exceptions, type_check)
     fail_already_registered = globals().get("_fail_already_registered", fail_already_registered)
     if not uniqueness_key and fail_already_registered and get_registered_type(type_class):

--- a/jsonargparse_tests/test_typing.py
+++ b/jsonargparse_tests/test_typing.py
@@ -376,6 +376,14 @@ def test_register_type_datetime(parser):
     pytest.raises(ValueError, lambda: register_type(datetime))  # different registration not okay
 
 
+def test_register_not_a_class_type_failure():
+    class SomeClass:
+        pass
+
+    with pytest.raises(ValueError, match="Expected type_class to be a class"):
+        register_type(Union[SomeClass, int])
+
+
 class RegisterOnFirstUse:
     pass
 


### PR DESCRIPTION
## What does this PR do?

Improves error message from #791

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
