### PR TITLE
Fix failure when parsing deeply nested dataclass with a union parent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Fixed
   <https://github.com/omni-us/jsonargparse/pull/834>`__).
 - Validation of defaults getting stuck for path with ``-`` (stdin) default
   (`#837 <https://github.com/omni-us/jsonargparse/pull/837>`__).
+- Failure when parsing deeply nested dataclass with a union parent (`#839
+  <https://github.com/omni-us/jsonargparse/pull/839>`__).
 
 
 v4.45.0 (2025-12-26)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1522,7 +1522,7 @@ def adapt_class_type(
             namespace=prev_init_args,
             defaults=sub_defaults.get(),
         )
-        return value
+        return _subclasses_disabled_remove_class_path(value, typehint)
 
     if serialize:
         if init_args:
@@ -1548,9 +1548,12 @@ def adapt_class_type(
                     val = load_value(val, simple_types=True)
             value["dict_kwargs"][key] = val
 
+    return _subclasses_disabled_remove_class_path(value, typehint)
+
+
+def _subclasses_disabled_remove_class_path(value, typehint):
     if is_subclasses_disabled(typehint) and value.class_path == get_import_path(typehint):
         value = Namespace({**value.get("init_args", {}), **value.get("dict_kwargs", {})})
-
     return value
 
 

--- a/jsonargparse_tests/test_dataclasses.py
+++ b/jsonargparse_tests/test_dataclasses.py
@@ -716,6 +716,28 @@ def test_union_dataclasses(parser):
     assert isinstance(init.data.a_or_b, SubB)
 
 
+@dataclasses.dataclass
+class File:
+    name: str
+
+
+@dataclasses.dataclass
+class FilePath:
+    folder: str
+    file: File
+
+
+@dataclasses.dataclass
+class PathParent:
+    path: Union[FilePath, bool]
+
+
+def test_deeply_nested_dataclass_in_union(parser):
+    parser.add_class_arguments(PathParent, "parent")
+    cfg = parser.parse_args(["--parent.path.folder=/tmp", "--parent.path.file.name=data.txt"])
+    assert cfg.parent.path == Namespace(folder="/tmp", file=Namespace(name="data.txt"))
+
+
 if type_alias_type:
     IntOrString = type_alias_type("IntOrString", Union[int, str])
 


### PR DESCRIPTION
## What does this PR do?

Fixes #838

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
