### PR TITLE
Skip pickle tests in Python 3.14.3

### DIFF
--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -1160,6 +1160,7 @@ def test_parse_known_args_not_implemented_without_caller_module(parser):
         pytest.raises(NotImplementedError, lambda: parser.parse_known_args([]))
 
 
+@pytest.mark.skipif(sys.version_info[:3] == (3, 14, 3), reason="not pickleable in Python 3.14.3")
 def test_pickle_parser(example_parser):
     parser = pickle.loads(pickle.dumps(example_parser))
     assert example_parser.get_defaults() == parser.get_defaults()
@@ -1181,6 +1182,7 @@ def test_get_argument_group_class_failure(logger):
     assert "Failed to create ArgumentGroup subclass based on" in logs.getvalue()
 
 
+@pytest.mark.skipif(sys.version_info[:3] == (3, 14, 3), reason="not pickleable in Python 3.14.3")
 def test_get_argument_group_class_underscores_to_dashes():
     parser = UnderscoresToDashesParser()
     parser.add_argument("--int_value", type=int, default=1)

--- a/jsonargparse_tests/test_omegaconf.py
+++ b/jsonargparse_tests/test_omegaconf.py
@@ -4,6 +4,7 @@ import json
 import math
 import multiprocessing
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
@@ -234,6 +235,7 @@ def parse_in_spawned_process(queue, parser, args):
 
 
 @skip_if_omegaconf_unavailable
+@pytest.mark.skipif(sys.version_info[:3] == (3, 14, 3), reason="not pickleable in Python 3.14.3")
 def test_omegaconf_in_spawned_process(parser):
     parser.parser_mode = "omegaconf"
     parser.add_argument("--dict", type=dict)


### PR DESCRIPTION
## What does this PR do?

Parsers in Python 3.14.3 are not pickleable. Already fixed in https://github.com/python/cpython/pull/144783 but needs to wait for the fix to be included in a release.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [n/a] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
