### PR TITLE
Fix positional arguments with default and nargs '*' or '?'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ paths are considered internals and can change in minor and patch releases.
 v4.47.0 (unreleased)
 --------------------
 
+Fixed
+^^^^^
+- Positional arguments with ``nargs="*"`` or ``nargs="?"`` now correctly allow
+  default values, matching standard argparse behavior (`#846
+  <https://github.com/omni-us/jsonargparse/pull/846>`__).
+
 Changed
 ^^^^^^^
 - Tests are no longer installed by default, there is a separate

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -146,7 +146,12 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
         ActionJsonnet._check_ext_vars_action(parser, action)
         if is_meta_key(action.dest):
             raise ValueError(f'Argument with destination name "{action.dest}" not allowed.')
-        if action.option_strings == [] and "default" in kwargs and kwargs["default"] is not argparse.SUPPRESS:
+        if (
+            action.option_strings == []
+            and "default" in kwargs
+            and kwargs["default"] is not argparse.SUPPRESS
+            and action.nargs not in ("*", "?")
+        ):
             raise ValueError("Positional arguments not allowed to have a default value.")
         validate_default(self, action)
         if action.help is None:

--- a/jsonargparse_tests/test_core.py
+++ b/jsonargparse_tests/test_core.py
@@ -53,6 +53,19 @@ def test_add_argument_positional_with_default(parser):
         parser.add_argument("pos", default="abc")
 
 
+def test_add_argument_positional_with_default_nargs_star(parser):
+    parser.add_argument("pos", nargs="*", default=["abc"])
+    assert parser.parse_args([]) == Namespace(pos=["abc"])
+    assert parser.parse_args(["x"]) == Namespace(pos=["x"])
+    assert parser.parse_args(["x", "y"]) == Namespace(pos=["x", "y"])
+
+
+def test_add_argument_positional_with_default_nargs_question(parser):
+    parser.add_argument("pos", nargs="?", default="abc")
+    assert parser.parse_args([]) == Namespace(pos="abc")
+    assert parser.parse_args(["x"]) == Namespace(pos="x")
+
+
 def test_parse_args_simple(parser):
     parser.add_argument("--op", type=int)
     assert parser.parse_args(["--op=1"]) == Namespace(op=1)


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
