### PR TITLE
Fix --help failures for options without explicit help text (#852).

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ Fixed
 - Subcommand names now correctly take precedence over top-level option strings
   with the same name, fixing a failure during typed sub-default processing
   (`#853 <https://github.com/omni-us/jsonargparse/pull/853>`__).
+- ``--help`` no longer fails with ``IndexError`` for options without explicit
+  help text while keeping ``argparse`` compatibility for ``help=None`` (`#854
+  <https://github.com/omni-us/jsonargparse/pull/854>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -48,7 +48,7 @@ from ._completions import (
     handle_completions,
 )
 from ._deprecated import ParserDeprecations, deprecated_skip_check, deprecated_yaml_comments
-from ._formatters import DefaultHelpFormatter, empty_help, get_env_var
+from ._formatters import DefaultHelpFormatter, get_env_var
 from ._jsonnet import ActionJsonnet
 from ._jsonschema import ActionJsonSchema
 from ._link_arguments import ActionLink, ArgumentLinking
@@ -154,8 +154,6 @@ class ActionsContainer(SignatureArguments, argparse._ActionsContainer):
         ):
             raise ValueError("Positional arguments not allowed to have a default value.")
         validate_default(self, action)
-        if action.help is None:
-            action.help = empty_help
         if action.required:
             parser.required_args.add(action.dest)  # type: ignore[union-attr]
             action._required = True  # type: ignore[attr-defined]

--- a/jsonargparse/_formatters.py
+++ b/jsonargparse/_formatters.py
@@ -40,9 +40,6 @@ from ._typehints import ActionTypeHint, type_to_str
 __all__ = ["DefaultHelpFormatter"]
 
 
-empty_help: str = "_EMPTY_HELP_"
-
-
 class PercentTemplate(Template):
     delimiter = "%"
     pattern = r"""
@@ -100,7 +97,7 @@ class YAMLCommentFormatter:
                 text = None
                 if full_key in group_titles and isinstance(cfg[key], dict):
                     text = group_titles[full_key]
-                elif action is not None and action.help not in {None, SUPPRESS}:
+                elif action is not None and action.help != SUPPRESS:
                     text = self.help_formatter._expand_help(action)
                 if isinstance(cfg[key], dict):
                     if text:
@@ -175,8 +172,9 @@ class DefaultHelpFormatter(HelpFormatterDeprecations, HelpFormatter):
     """
 
     def _get_help_string(self, action: Action) -> str:
-        action_help = " " if action.help == empty_help else action.help
-        assert isinstance(action_help, str)
+        if getattr(action, "_jsonargparse_preexpanded_help", False):
+            return action.help or ""
+        action_help = action.help or ""
         if isinstance(action, ActionConfigFile):
             return action_help
         if isinstance(action, _HelpAction):
@@ -200,6 +198,19 @@ class DefaultHelpFormatter(HelpFormatterDeprecations, HelpFormatter):
         if isinstance(action, ActionTypeHint):
             help_str += action.extra_help()
         return action_help + (" (" + help_str + ")" if help_str else "")
+
+    def _format_action(self, action: Action) -> str:
+        if action.help is None and action.help != SUPPRESS:
+            help_text = self._expand_help(action)
+            if help_text and help_text.strip():
+                action.help = help_text
+                action._jsonargparse_preexpanded_help = True  # type: ignore[attr-defined]
+                try:
+                    return super()._format_action(action)
+                finally:
+                    del action._jsonargparse_preexpanded_help  # type: ignore[attr-defined]
+                    action.help = None
+        return super()._format_action(action)
 
     def _format_usage(self, usage, actions, *args, **kwargs) -> str:
         actions = filter_non_parsing_actions(actions)

--- a/jsonargparse/_link_arguments.py
+++ b/jsonargparse/_link_arguments.py
@@ -6,7 +6,6 @@ from argparse import Action as ArgparseAction
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
-from importlib import import_module
 from typing import Any, Callable, Optional, Union
 
 from ._actions import (
@@ -227,7 +226,7 @@ class ActionLink(Action):
                 assert isinstance(self.target[1], ArgparseAction)
                 type_attr = getattr(self.target[1], "_typehint", self.target[1].type)
                 help_str = self.target[1].help
-            if help_str == import_module("jsonargparse._formatters").empty_help:
+            if help_str is None:
                 help_str = f"Target '{self.target[1].dest}' lacks type and help"
 
         super().__init__(


### PR DESCRIPTION
## What does this PR do?

Fixes #852 help bug.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
