### PR TITLE
Fix environment variable precedence over default_config_files for subcommands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ Fixed
 - ``store_true`` and ``store_false`` arguments now parse boolean environment
   variable values as ``true``/``false`` and raise a clear error for invalid
   values (`#858 <https://github.com/omni-us/jsonargparse/pull/858>`__).
+- Environment variable overrides now correctly take precedence over
+  ``default_config_files`` values for subcommands and nested subsubcommands
+  (`#862 <https://github.com/omni-us/jsonargparse/pull/862>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -698,7 +698,7 @@ class _ActionSubCommands(_SubParsersAction):
         if subcommand in self._name_parser_map:
             subparser = self._name_parser_map[subcommand]
             subnamespace = namespace.get(subcommand).clone() if subcommand in namespace else None
-            kwargs = dict(_skip_validation=True, **parse_kwargs.get())
+            kwargs = dict(_skip_validation=True, _namespace_as_config=True, **parse_kwargs.get())
             namespace[subcommand] = subparser.parse_args(arg_strings, namespace=subnamespace, **kwargs)
 
     @staticmethod

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -429,7 +429,9 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
         Raises:
             ArgumentError: If the parsing fails and ``exit_on_error=True``.
         """
-        skip_validation = get_private_kwargs(kwargs, _skip_validation=False)
+        skip_validation, namespace_as_config = get_private_kwargs(
+            kwargs, _skip_validation=False, _namespace_as_config=False
+        )
         return_parser_if_captured(self)
         handle_completions(self)
 
@@ -444,7 +446,15 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
         try:
             cfg = self._parse_defaults_and_environ(defaults, env)
             if namespace:
-                cfg = self.merge_config(namespace, cfg)
+                if namespace_as_config:
+                    cfg = self._parse_defaults_and_environ(defaults, env=False)
+                    cfg = self.merge_config(namespace, cfg)
+                    if env or (env is None and self._default_env):
+                        with parser_context(load_value_mode=self.parser_mode):
+                            cfg_env = self._load_env_vars(env=os.environ, defaults=defaults)
+                        cfg = self.merge_config(cfg_env, cfg)
+                else:
+                    cfg = self.merge_config(namespace, cfg)
 
             with _ActionSubCommands.parse_kwargs_context({"env": env, "defaults": defaults}):
                 cfg, unk = self.parse_known_args(args=args, namespace=cfg)

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -219,6 +219,24 @@ def test_subcommands_help_default_env_true(subcommands_parser):
     assert "ENV:   APP_SUBCOMMAND" in help_str
 
 
+def test_subcommand_env_overrides_default_config(parser, subparser, tmp_cwd):
+    Path("config.json").write_text(json.dumps({"create": {"stats": True}}))
+    parser.env_prefix = "APP"
+    parser.default_env = True
+    parser.default_config_files = ["config.json"]
+
+    subparser.add_argument("--stats", action="store_true")
+    subcommands = parser.add_subcommands(required=False)
+    subcommands.add_subcommand("create", subparser)
+
+    cfg = parser.parse_args(["create"])
+    assert cfg.create.stats is True
+
+    with patch.dict(os.environ, {"APP_CREATE__STATS": "false"}):
+        cfg = parser.parse_args(["create"])
+    assert cfg.create.stats is False
+
+
 def test_subcommand_required_false(parser, subparser):
     subcommands = parser.add_subcommands(required=False)
     subcommands.add_subcommand("foo", subparser)
@@ -450,6 +468,30 @@ def test_subsubcommand_default_config_files(parser, subparser, subsubparser, def
     assert cfg.clone(with_meta=False) == Namespace(
         val0=123, subcommand="cmd1", cmd1=Namespace(val1=456, subcommand="cmd2", cmd2=Namespace(val2=789))
     )
+
+
+def test_subsubcommand_env_overrides_default_config(parser, subparser, subsubparser, tmp_cwd):
+    config = {"cmd1": {"cmd2": {"flag": True}}}
+    Path("config.json").write_text(json.dumps(config))
+    parser.env_prefix = "APP"
+    parser.default_env = True
+    parser.default_config_files = ["config.json"]
+    subsubparser.add_argument("--flag", action="store_true")
+
+    subcommands = parser.add_subcommands(required=False)
+    subcommands.add_subcommand("cmd1", subparser)
+    subsubcommands = subparser.add_subcommands(required=False)
+    subsubcommands.add_subcommand("cmd2", subsubparser)
+
+    cfg = parser.parse_args(["cmd1", "cmd2"])
+    assert cfg.cmd1.cmd2.flag is True
+
+    with patch.dict(
+        os.environ,
+        {"APP_SUBCOMMAND": "cmd1", "APP_CMD1__SUBCOMMAND": "cmd2", "APP_CMD1__CMD2__FLAG": "false"},
+    ):
+        cfg = parser.parse_args([])
+    assert cfg.cmd1.cmd2.flag is False
 
 
 def test_subcommands_in_default_config_files(parser, subtests, tmp_cwd):


### PR DESCRIPTION
## What does this PR do?

Fixes #860

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
