### PR TITLE
Deprecate ArgumentParser.instantiate_classes in favor of ArgumentParser.instantiate

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -72,8 +72,8 @@ result = parser.parse_args([f"--config={config}", "--key2=val2", ...])
 # If the problem is in the parsed result, print it to stdout
 print(parser.dump(result))
 
-# If the problem is in class instantiation
-parser.instantiate_classes(result)
+# If the problem is in instantiation
+parser.instantiate(result)
 ```
 -->
 

--- a/.github/ISSUE_TEMPLATE/2-regression.md
+++ b/.github/ISSUE_TEMPLATE/2-regression.md
@@ -69,8 +69,8 @@ config = json.dumps(
 # If the problem is when parsing arguments
 result = parser.parse_args([f"--config={config}", "--key2=val2", ...])
 
-# If the problem is in class instantiation
-parser.instantiate_classes(result)
+# If the problem is in instantiation
+parser.instantiate(result)
 ```
 
 2. Preferably, run git bisect and include in the report the git commit hash that

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Deprecated
   argument) was deprecated and will be removed in v5.0.0. Pass components
   explicitly; explicit is better than implicit (`#895
   <https://github.com/omni-us/jsonargparse/pull/895>`__).
+- ``instantiate_classes`` is deprecated and will be removed in v5.0.0. Instead
+  use ``instantiate`` (`#896
+  <https://github.com/omni-us/jsonargparse/pull/896>`__).
 
 
 v4.48.0 (2026-04-10)

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -483,10 +483,9 @@ Some notes about this support are:
   null], default: null``.
 
 - Normal classes can be used as a type, which are specified with a dict
-  containing ``class_path`` and optionally ``init_args``.
-  :meth:`instantiate_classes <.ArgumentParser.instantiate_classes>` can be used
-  to instantiate all classes in a config object. For more details see
-  :ref:`sub-classes`.
+  containing ``class_path`` and optionally ``init_args``. :meth:`instantiate
+  <.ArgumentParser.instantiate>` can be used to instantiate all classes in a
+  config object. For more details see :ref:`sub-classes`.
 
 - ``Protocol`` types are also supported the same as subclasses. The protocols
   are not required to be ``runtime_checkable``. But the accepted classes must
@@ -513,10 +512,10 @@ Some notes about this support are:
   object or by giving a dict with a ``class_path`` and optionally ``init_args``
   entries. The specified class must either instantiate into a callable or be a
   subclass of the return type of the callable. For these cases running
-  :meth:`instantiate_classes <.ArgumentParser.instantiate_classes>` will
-  instantiate the class or provide a function that returns the instance of the
-  class. For more details see :ref:`callable-type`. Currently the callable's
-  argument and return types are not validated.
+  :meth:`instantiate <.ArgumentParser.instantiate>` will instantiate the class
+  or provide a function that returns the instance of the class. For more details
+  see :ref:`callable-type`. Currently the callable's argument and return types
+  are not validated.
 
 - ``TypeAliasType`` is supported with values parsed as the aliased type and the
   alias shown as the argument type in help.
@@ -1020,7 +1019,7 @@ A second option is a class that once instantiated becomes callable:
     >>> cfg = parser.parse_args(["--callable", str(value)])
     >>> cfg.callable
     Namespace(class_path='__main__.OffsetSum', init_args=Namespace(offset=3))
-    >>> init = parser.instantiate_classes(cfg)
+    >>> init = parser.instantiate(cfg)
     >>> init.callable(5)
     8
 
@@ -1420,11 +1419,10 @@ and ``flag`` as an optional boolean with default value false.
 
 Instantiation of several classes added with :meth:`add_class_arguments
 <.SignatureArguments.add_class_arguments>` can be done more simply for an entire
-config object using :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>`. For the example above running ``cfg =
-parser.instantiate_classes(cfg)`` would result in ``cfg.myclass.init``
-containing an instance of ``MyClass`` initialized with whatever command line
-arguments were parsed.
+config object using :meth:`instantiate <.ArgumentParser.instantiate>`. For the
+example above running ``cfg = parser.instantiate(cfg)`` would result in
+``cfg.myclass.init`` containing an instance of ``MyClass`` initialized with
+whatever command line arguments were parsed.
 
 When parsing from a config file (see :ref:`configuration-files`) all the values
 can be given in a single config file. For convenience it is also possible that
@@ -1569,9 +1567,8 @@ Classes from functions
 ----------------------
 
 In some cases there are functions which return an instance of a class. To add
-this to a parser such that :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` calls this function, the example above
-would change to:
+this to a parser such that :meth:`instantiate <.ArgumentParser.instantiate>`
+calls this function, the example above would change to:
 
 .. testsetup:: class_from_function
 
@@ -1653,7 +1650,7 @@ Take for example the following parsing and instantiation:
     parser = ArgumentParser()
     parser.add_argument("--myclass", type=MyClass)
     cfg = parser.parse_args()
-    cfg_init = parser.instantiate_classes(cfg)
+    cfg_init = parser.instantiate(cfg)
 
 If ``MyClass.__init__`` has ``**kwargs`` with some unresolved parameters, the
 following could be a valid config file:
@@ -1850,9 +1847,8 @@ parameters behave differently and are shown in the help with the default like
 these parameters are not included in :meth:`get_defaults
 <.ArgumentParser.get_defaults>` or the output of ``--print_config``. This is
 necessary because the parser does not know which of the calls will be used at
-runtime, and adding them would cause :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` to fail due to unexpected keyword
-arguments.
+runtime, and adding them would cause :meth:`instantiate
+<.ArgumentParser.instantiate>` to fail due to unexpected keyword arguments.
 
 .. note::
 
@@ -1937,8 +1933,8 @@ instantiate it. When parsing, it will be checked that the class can be imported,
 that it is a subclass of the given type and that ``init_args`` values correspond
 to valid arguments to instantiate it. After parsing, the config object will
 include the ``class_path`` and ``init_args`` entries. To get a config object
-with all nested subclasses instantiated, the :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` method is used.
+with all nested subclasses instantiated, the :meth:`instantiate
+<.ArgumentParser.instantiate>` method is used.
 
 In addition to using a class as type hint in signatures, for low level
 construction of parsers, there are also the methods :meth:`add_class_arguments
@@ -1992,7 +1988,7 @@ Then in Python:
     >>> cfg.myclass.calendar.as_dict()
     {'class_path': 'calendar.Calendar', 'init_args': {'firstweekday': 1}}
 
-    >>> cfg = parser.instantiate_classes(cfg)
+    >>> cfg = parser.instantiate(cfg)
     >>> isinstance(cfg.myclass, MyClass)
     True
     >>> isinstance(cfg.myclass.calendar, Calendar)
@@ -2041,11 +2037,11 @@ As explained at the beginning of section :ref:`dependency-injection`, callables
 that return instances of classes, referred to as instance factories, represent
 an alternative approach to dependency injection. This is useful to support
 dependency injection of classes that require parameters that are only available
-after injection. For this case, when :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` is run, a partial function is provided,
-which might accept parameters and return the instance of the class. Two options
-are possible: using ``Callable`` or ``Protocol``. To illustrate the
-``Callable`` option, take for example the classes:
+after injection. For this case, when :meth:`instantiate
+<.ArgumentParser.instantiate>` is run, a partial function is provided, which
+might accept parameters and return the instance of the class. Two options are
+possible: using ``Callable`` or ``Protocol``. To illustrate the ``Callable``
+option, take for example the classes:
 
 .. testcode:: callable
 
@@ -2079,7 +2075,7 @@ A possible parser and callable behavior would be:
     >>> cfg = parser.parse_args(["--optimizer", str(value)])
     >>> cfg.optimizer
     Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.01))
-    >>> init = parser.instantiate_classes(cfg)
+    >>> init = parser.instantiate(cfg)
     >>> optimizer = init.optimizer([1, 2, 3])
     >>> isinstance(optimizer, SGD)
     True
@@ -2112,7 +2108,7 @@ Then a parser and behavior could be:
     >>> cfg = parser.get_defaults()
     >>> cfg.model.optimizer
     Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.05))
-    >>> init = parser.instantiate_classes(cfg)
+    >>> init = parser.instantiate(cfg)
     >>> optimizer = init.model.optimizer([1, 2, 3])
     >>> optimizer.params, optimizer.lr
     ([1, 2, 3], 0.05)
@@ -2159,7 +2155,7 @@ Then a parser and protocol behavior would be:
     >>> cfg = parser.parse_args(["--optimizer", str(value)])
     >>> cfg.optimizer
     Namespace(class_path='__main__.SGD', init_args=Namespace(lr=0.02))
-    >>> init = parser.instantiate_classes(cfg)
+    >>> init = parser.instantiate(cfg)
     >>> optimizer = init.optimizer(params=[6, 5])
     >>> optimizer.params, optimizer.lr
     ([6, 5], 0.02)
@@ -2249,9 +2245,9 @@ are supported with a particular behavior and recommendations. An example is:
 Adding this class to a parser will work without issues. The :ref:`ast-resolver`
 in limited cases determines how to instantiate the original default. The parsing
 methods would provide a dict with ``class_path`` and ``init_args`` instead of
-the class instance. Furthermore, if :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` is used, a new instance of the class is
-created, thereby avoiding issues related to the mutability of the default.
+the class instance. Furthermore, if :meth:`instantiate
+<.ArgumentParser.instantiate>` is used, a new instance of the class is created,
+thereby avoiding issues related to the mutability of the default.
 
 Since the :ref:`ast-resolver` only supports limited cases, or when the source
 code is not available, a second approach is to use the special function
@@ -2419,7 +2415,7 @@ behavior can be obtained by using the :meth:`link_arguments
 There are two types of links, defined with ``apply_on='parse'`` or
 ``apply_on='instantiate'``. As the names suggest, the former are set when
 calling one of the parse methods and the latter are set when calling
-:meth:`instantiate_classes <.ArgumentParser.instantiate_classes>`.
+:meth:`instantiate <.ArgumentParser.instantiate>`.
 
 Applied on parse
 ----------------
@@ -2482,10 +2478,9 @@ For instantiation links, sources can be class groups (added with
 subclass arguments (see :ref:`sub-classes`). The source key can be the entire
 instantiated object or an attribute of the object. The target key has to be a
 single argument and can be inside init_args of a subclass. The order of
-instantiation used by :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` is automatically determined based on the
-links. The set of all instantiation links must be a directed acyclic graph. An
-example would be the following:
+instantiation used by :meth:`instantiate <.ArgumentParser.instantiate>` is
+automatically determined based on the links. The set of all instantiation links
+must be a directed acyclic graph. An example would be the following:
 
 .. testcode::
 
@@ -2504,9 +2499,9 @@ example would be the following:
     parser.add_class_arguments(Data, "data")
     parser.link_arguments("data.num_classes", "model.num_classes", apply_on="instantiate")
 
-This link would imply that :meth:`instantiate_classes
-<.ArgumentParser.instantiate_classes>` instantiates ``Data`` first, then use the
-``num_classes`` attribute to instantiate ``Model``.
+This link would imply that :meth:`instantiate <.ArgumentParser.instantiate>`
+instantiates ``Data`` first, then use the ``num_classes`` attribute to
+instantiate ``Model``.
 
 
 OmegaConf variable interpolation

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Powerful argparse-like low level parsers:
     parser.add_class_arguments(SomeClass, "class")  # add class parameters
     ...
     cfg = parser.parse_args()
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     ...
 
 

--- a/jsonargparse/_cli.py
+++ b/jsonargparse/_cli.py
@@ -91,7 +91,7 @@ def auto_cli(
             deprecation_warning_cli_return_parser(stacklevel)
             return parser
         cfg = parser.parse_args(args)
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         return _run_component(components, init)
 
     elif isinstance(components, list):
@@ -105,7 +105,7 @@ def auto_cli(
         deprecation_warning_cli_return_parser(stacklevel)
         return parser
     cfg = parser.parse_args(args)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     components_ns = dict_to_namespace(components)
     subcommand = init.get("subcommand")
     while isinstance(init.get(subcommand), Namespace) and isinstance(init[subcommand].get("subcommand"), str):

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -1211,7 +1211,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
         subclasses: bool = True,
         prepend: bool = False,
     ) -> None:
-        """Adds a custom instantiator for a class type. Used by ``instantiate_classes``.
+        """Adds a custom instantiator for a class type. Used by ``instantiate``.
 
         Instantiator functions are expected to have as signature ``(class_type:
         Type[ClassType], *args, **kwargs) -> ClassType``.
@@ -1254,19 +1254,45 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
             instantiators.update({k: v for k, v in context_instantiators.items() if k not in instantiators})
         return instantiators
 
-    def instantiate_classes(
+    def instantiate(
         self,
         cfg: Namespace,
         instantiate_groups: bool = True,
     ) -> Namespace:
-        """Recursively instantiates all subclasses defined by ``class_path`` + ``init_args`` and class groups.
+        """Instantiates all signature components in a configuration namespace.
+
+        Processes the configuration recursively, converting each signature
+        component registered with the parser into its corresponding Python
+        object:
+
+        - **Class/subclass type arguments** (``add_argument`` with a class type
+          or ``add_class_arguments``/``add_subclass_arguments``): An object with
+          ``class_path`` and optionally ``init_args`` is replaced by an instance
+          of the referenced class, created by calling
+          ``class_type(**init_args)``. For the case of classes with disabled
+          subclasses, the namespace can have directly the init args without the
+          ``class_path`` + ``init_args`` wrapper.
+
+        - **Callable type arguments**: A dot-import string pointing to a
+          function or method is resolved to the callable object. When
+          ``class_path``/``init_args`` is given instead and the class
+          instantiates into a callable (or is a subclass of the callable's
+          return type), the result is either a class instance or — when not all
+          call arguments are provided yet — a :func:`functools.partial` bound to
+          the given ``init_args``.
+
+        - **Instantiation order**: Components are processed in the order
+          determined by argument links applied on instantiation.
 
         Args:
-            cfg: The configuration object to use.
+            cfg: The configuration object to use. Must have been produced by
+                one of the ``parse_*`` methods and not modified in a way that
+                breaks the structure expected by the parser.
             instantiate_groups: Whether class groups should be instantiated.
 
         Returns:
-            A configuration object with all subclasses and class groups instantiated.
+            A new configuration object where every registered signature
+            component has been replaced by its corresponding Python object.
         """
         components: list[Union[ActionTypeHint, _ActionConfigLoad, ArgumentGroup]] = []
         for action in filter_non_parsing_actions(self._actions):
@@ -1313,7 +1339,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
 
         subcommand, subparser = get_subcommand(self, cfg, fail_no_subcommand=False)
         if subcommand is not None and subparser is not None:
-            cfg[subcommand] = subparser.instantiate_classes(cfg[subcommand], instantiate_groups=instantiate_groups)
+            cfg[subcommand] = subparser.instantiate(cfg[subcommand], instantiate_groups=instantiate_groups)
 
         return cfg
 

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -159,18 +159,6 @@ def parse_as_dict_patch():
     patch_parse_method("parse_env")
     patch_parse_method("parse_string")
 
-    # Patch instantiate_classes
-    def patched_instantiate_classes(
-        self, cfg: Union[Namespace, Dict[str, Any]], **kwargs
-    ) -> Union[Namespace, Dict[str, Any]]:
-        if isinstance(cfg, dict):
-            cfg = self._apply_actions(cfg)
-        cfg = self._unpatched_instantiate_classes(cfg, **kwargs)
-        return cfg.as_dict() if self._parse_as_dict else cfg
-
-    ArgumentParser._unpatched_instantiate_classes = ArgumentParser.instantiate_classes
-    ArgumentParser.instantiate_classes = patched_instantiate_classes
-
     # Patch dump
     def patched_dump(self, cfg: Union[Namespace, Dict[str, Any]], *args, **kwargs) -> str:
         if isinstance(cfg, dict):
@@ -634,11 +622,21 @@ class ParserDeprecations:
             raise ValueError("default_meta expects a boolean.")
 
     @deprecated("""
+        ``instantiate_classes`` was deprecated in v4.49.0 and will be removed in v5.0.0.
+        Instead use ``instantiate``.
+    """)
+    def instantiate_classes(self, cfg: Union[Namespace, Dict[str, Any]], **kwargs) -> Union[Namespace, Dict[str, Any]]:
+        if isinstance(cfg, dict):
+            cfg = self._apply_actions(cfg)  # type: ignore[attr-defined]
+        cfg = self.instantiate(cfg, **kwargs)  # type: ignore[attr-defined]
+        return cfg.as_dict() if self._parse_as_dict else cfg  # type: ignore[attr-defined]
+
+    @deprecated("""
         instantiate_subclasses was deprecated in v4.0.0 and will be removed in v5.0.0.
-        Instead use instantiate_classes.
+        Instead use instantiate.
     """)
     def instantiate_subclasses(self, cfg: Namespace) -> Namespace:
-        return self.instantiate_classes(cfg, instantiate_groups=False)  # type: ignore[attr-defined]
+        return self.instantiate(cfg, instantiate_groups=False)  # type: ignore[attr-defined]
 
     @deprecated("""
         add_dataclass_arguments was deprecated in v4.35.0 and will be removed in

--- a/jsonargparse/_from_config.py
+++ b/jsonargparse/_from_config.py
@@ -87,7 +87,7 @@ def _parse_class_kwargs_from_config(cls: Type[T], config: Union[str, PathLike, d
     for required in iter_required_keys(parser):
         clear_required(parser, required)
     cfg = parser.parse_object(config, defaults=False)
-    return parser.instantiate_classes(cfg).as_dict(), cls
+    return parser.instantiate(cfg).as_dict(), cls
 
 
 def _override_init_defaults(cls: Type[T], parser_kwargs: dict) -> None:

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -66,7 +66,8 @@ class SignatureArguments(LoggerProperty):
             as_positional: Whether to add required parameters as positional arguments.
             default: Default value used to override parameter defaults.
             skip: Names of parameters or number of positionals that should be skipped.
-            instantiate: Whether the class group should be instantiated by ``instantiate_classes``.
+            instantiate: Whether the class group should be instantiated by
+                :meth:`instantiate <.ArgumentParser.instantiate>`.
             fail_untyped: Whether to raise exception if a required parameter does not have a type.
             sub_configs: Whether subclass type hints should be loadable from inner config file.
 
@@ -254,7 +255,7 @@ class SignatureArguments(LoggerProperty):
             skip: Names of parameters or number of positionals that should be skipped.
             fail_untyped: Whether to raise exception if a required parameter does not have a type.
             sub_configs: Whether subclass type hints should be loadable from inner config file.
-            instantiate: Whether the class group should be instantiated by ``instantiate_classes``.
+            instantiate: Whether the class group should be instantiated.
 
         Returns:
             The list of arguments added.

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1493,7 +1493,7 @@ def adapt_class_type(
     init_args = value.get("init_args", Namespace())
 
     if instantiate_classes:
-        init_args = parser.instantiate_classes(init_args)
+        init_args = parser.instantiate(init_args)
         if not sub_add_kwargs.get("instantiate", True):
             if init_args:
                 value["init_args"] = init_args

--- a/jsonargparse_tests/test_attrs.py
+++ b/jsonargparse_tests/test_attrs.py
@@ -75,7 +75,7 @@ class TestAttrs:
         help_str = get_parser_help(parser)
         assert "--data.p1" not in help_str
         assert cfg == Namespace()
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert init.data.p1 == {}
 
     def test_nested_with_default(self, parser):

--- a/jsonargparse_tests/test_dataclasses.py
+++ b/jsonargparse_tests/test_dataclasses.py
@@ -93,8 +93,8 @@ def test_add_class_arguments(parser, subtests):
         assert dataclasses.asdict(DataClassA()) == dump["a"]
         assert dataclasses.asdict(DataClassB()) == dump["b"]
 
-    with subtests.test("instantiate_classes"):
-        init = parser.instantiate_classes(cfg)
+    with subtests.test("instantiate"):
+        init = parser.instantiate(cfg)
         assert isinstance(init["a"], DataClassA)
         assert isinstance(init["b"], DataClassB)
         assert isinstance(init["b"].b2, DataClassA)
@@ -154,7 +154,7 @@ def test_dashes_in_nested_dataclass():
     parser = UnderscoresToDashesParser(default_env=True)
     parser.add_class_arguments(NestedDefaultsD)
     ns = parser.parse_args([])
-    cfg = parser.instantiate_classes(ns)
+    cfg = parser.instantiate(ns)
     assert cfg.c_with_dash.field_with_dash == 5
 
 
@@ -178,7 +178,7 @@ def test_add_class_with_dataclass_attributes(parser):
     assert dataclasses.asdict(DataClassA()) == dump["g"]["a1"]
     assert dataclasses.asdict(DataClassB()) == dump["g"]["a2"]
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.g.a1, DataClassA)
     assert isinstance(init.g.a2, DataClassB)
     assert isinstance(init.g.a2.b2, DataClassA)
@@ -206,7 +206,7 @@ def test_add_class_dataclass_typehint_in_subclass(parser):
     assert cfg.c1.init_args.a1.b2.a1 == 7
     assert isinstance(cfg.c1.init_args.a1.b2.a1, PositiveInt)
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.c1, SubBaseClass)
     assert isinstance(init.c1.a1, DataClassB)
     assert isinstance(init.c1.a1.b2, DataClassA)
@@ -257,7 +257,7 @@ def test_add_argument_dataclass_type(parser):
     parser.add_argument("--b", type=DataClassB, default=DataClassB(b1=7.0))
     cfg = parser.get_defaults()
     assert Namespace(b1=7.0, b2=Namespace(a1=1, a2="x")) == cfg.b
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.b, DataClassB)
     assert isinstance(init.b.b2, DataClassA)
 
@@ -295,7 +295,7 @@ def test_dataclass_field_init_false(parser):
     assert parser.get_defaults() == Namespace()
     cfg = parser.parse_args([])
     assert cfg == Namespace()
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, DataInitFalse)
 
 
@@ -314,7 +314,7 @@ def test_nested_dataclass_field_init_false(parser):
     assert parser.get_defaults() == Namespace()
     cfg = parser.parse_args([])
     assert cfg == Namespace()
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, ParentDataInitFalse)
     assert isinstance(init.data.y, NestedDataInitFalse)
     assert init.data.y.x is False
@@ -351,7 +351,7 @@ def test_dataclass_fail_untyped_false(parser):
     init_args = '"init_args": {"c1": 1}'
 
     cfg = parser.parse_args(["--data.a1={" + class_path + ", " + init_args + "}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, DataUntypedAttribute)
     assert isinstance(init.data.a1, UntypedClass)
     assert isinstance(init.data.a2, str)
@@ -372,7 +372,7 @@ def test_instantiate_dataclass_within_classes(parser):
     parser.add_class_arguments(MainClass, "class")
     cfg = parser.parse_args([])
     assert cfg["class.data.name"] == "name"
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init["class"], MainClass)
     assert isinstance(init["class"].data, NestedData)
 
@@ -391,7 +391,7 @@ def test_list_nested_dataclass_required_attr(parser):
     parser.add_argument("--a", type=List[NestedRequiredAttr])
     cfg = parser.parse_args(['--a=[{"b": {"an_int": 3}}]'])
     assert cfg == Namespace(a=[Namespace(b=Namespace(an_int=3))])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.a[0].b, RequiredAttr)
     assert isinstance(init.a[0], NestedRequiredAttr)
 
@@ -453,7 +453,7 @@ def test_optional_dataclass_type_invalid_field(parser_optional_data):
 
 def test_optional_dataclass_type_instantiate(parser_optional_data):
     cfg = parser_optional_data.parse_args(['--data={"p1": "y", "p2": 2}'])
-    init = parser_optional_data.instantiate_classes(cfg)
+    init = parser_optional_data.instantiate(cfg)
     assert isinstance(init.data, Data)
     assert init.data.p1 == "y"
     assert init.data.p2 == 2
@@ -472,7 +472,7 @@ def test_optional_dataclass_type_missing_required_field(parser_optional_data):
 def test_optional_dataclass_type_null_value(parser_optional_data):
     cfg = parser_optional_data.parse_args(["--data=null"])
     assert cfg == Namespace(data=None)
-    assert cfg == parser_optional_data.instantiate_classes(cfg)
+    assert cfg == parser_optional_data.instantiate(cfg)
 
 
 @dataclasses.dataclass
@@ -493,7 +493,7 @@ def test_dataclass_with_optional_default(parser):
     parser.add_function_arguments(data_with_optional, "data")
     cfg = parser.parse_args([])
     assert cfg.data == Namespace(a=Namespace(b={"c": 3}))
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.data.a == DataWithOptionalA()
 
 
@@ -520,7 +520,7 @@ def test_dataclass_optional_dict_attribute(parser):
     parser.add_argument("--model", type=Optional[ModelConfig], default=ModelConfig(data={"A": 1, "B": 2}))
     cfg = parser.parse_args(["--model.data.A=4"])
     assert cfg.model["data"] == {"A": 4, "B": 2}
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.model == ModelConfig(data={"A": 4, "B": 2})
 
 
@@ -528,7 +528,7 @@ def test_dataclass_in_union_type(parser):
     parser.add_argument("--union", type=Optional[Union[Data, int]])
     cfg = parser.parse_args(["--union=1"])
     assert cfg == Namespace(union=1)
-    assert cfg == parser.instantiate_classes(cfg)
+    assert cfg == parser.instantiate(cfg)
     help_str = get_parser_help(parser)
     assert "--union.help" in help_str
     help_str = get_parse_args_stdout(parser, ["--union.help"])
@@ -538,7 +538,7 @@ def test_dataclass_in_union_type(parser):
 def test_dataclass_in_list_type(parser):
     parser.add_argument("--list", type=List[Data])
     cfg = parser.parse_args(['--list=[{"p1": "a"},{"p1": "b"}]'])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert ["a", "b"] == [d.p1 for d in init.list]
     assert isinstance(init.list[0], Data)
     assert isinstance(init.list[1], Data)
@@ -607,7 +607,7 @@ class GenericSubclass(GenericBase[str]):
 def test_generic_dataclass_subclass(parser):
     parser.add_class_arguments(GenericSubclass, "x")
     cfg = parser.parse_args(['--x.children=[{"value": "a"}, {"value": "b"}]'])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert cfg.x.children == (Namespace(value="a"), Namespace(value="b"))
     assert isinstance(init.x, GenericSubclass)
     assert isinstance(init.x.children[0], GenericChild)
@@ -638,14 +638,14 @@ def test_class_path_union_mixture_dataclass_and_class(parser, union_type):
 
     value = {"class_path": f"{__name__}.UnionData", "init_args": {"data_a": 2, "data_b": "x"}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.union, UnionData)
     assert dataclasses.asdict(init.union) == {"data_a": 2, "data_b": "x"}
     assert json_or_yaml_load(parser.dump(cfg))["union"] == value["init_args"]
 
     value = {"class_path": f"{__name__}.UnionClass", "init_args": {"prm_1": 1.2, "prm_2": False}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.union, UnionClass)
     assert init.union.prm_1 == 1.2
     assert json_or_yaml_load(parser.dump(cfg))["union"] == value
@@ -666,21 +666,21 @@ def test_class_path_union_dataclasses(parser):
 
     value = {"class_path": f"{__name__}.UnionData", "init_args": {"data_a": 2, "data_b": "x"}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.union, UnionData)
     assert dataclasses.asdict(init.union) == {"data_a": 2, "data_b": "x"}
     assert json_or_yaml_load(parser.dump(cfg))["union"] == value["init_args"]
 
     value = {"class_path": f"{__name__}.SingleParamChange", "init_args": {"p1": 2}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.union, SingleParamChange)
     assert dataclasses.asdict(init.union) == {"p1": 2, "p2": 0}
     assert json_or_yaml_load(parser.dump(cfg))["union"] == {"p1": 2, "p2": 0}
 
     value = {"class_path": f"{__name__}.Data", "init_args": {"p1": "x"}}
     cfg = parser.parse_args([f"--union={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.union, Data)
     assert dataclasses.asdict(init.union) == {"p1": "x", "p2": 0}
     assert json_or_yaml_load(parser.dump(cfg))["union"] == {"p1": "x", "p2": 0}
@@ -705,13 +705,13 @@ def test_union_dataclasses(parser):
     parser.add_class_arguments(SubAorB, "data")
 
     cfg = parser.parse_args([])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, SubAorB)
     assert isinstance(init.data.a_or_b, SubA)
 
     cfg = parser.parse_args(["--data.a_or_b.b=4"])
     assert cfg.data.a_or_b == Namespace(b=4.0)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, SubAorB)
     assert isinstance(init.data.a_or_b, SubB)
 
@@ -834,7 +834,7 @@ def test_add_subclass_dataclass_subclasses_enabled(parser, default, enable_subcl
 
     config = {"class_path": f"{__name__}.DataMain", "init_args": {"p1": 2}}
     cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, DataMain)
     assert dataclasses.asdict(init.data) == {"p1": 2}
     dump = json_or_yaml_load(parser.dump(cfg))["data"]
@@ -842,7 +842,7 @@ def test_add_subclass_dataclass_subclasses_enabled(parser, default, enable_subcl
 
     config = {"class_path": f"{__name__}.DataSub", "init_args": {"p2": "y"}}
     cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, DataSub)
     assert dataclasses.asdict(init.data) == {"p1": 1, "p2": "y"}
     dump = json_or_yaml_load(parser.dump(cfg))["data"]
@@ -866,7 +866,7 @@ def test_add_argument_dataclass_subclasses_enabled(parser, subtests, enable_subc
     with subtests.test("sub-param"):
         config = {"class_path": f"{__name__}.DataSub", "init_args": {"p2": "y"}}
         cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, DataSub)
         assert dataclasses.asdict(init.data) == {"p1": 2, "p2": "y"}
         dump = json_or_yaml_load(parser.dump(cfg))["data"]
@@ -875,7 +875,7 @@ def test_add_argument_dataclass_subclasses_enabled(parser, subtests, enable_subc
     with subtests.test("sub-default"):
         config = {"class_path": "DataSub", "init_args": {"p1": 4}}
         cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, DataSub)
         assert dataclasses.asdict(init.data) == {"p1": 4, "p2": "-"}
 
@@ -884,20 +884,20 @@ def test_add_argument_dataclass_subclasses_enabled(parser, subtests, enable_subc
         cfg = parser.parse_args([f"--data={json.dumps(config)}"])
         assert cfg.data == Namespace(class_path=f"{__name__}.DataSub", init_args=Namespace(p1=3, p2="x"))
         assert cfg.data.init_args.p1 == 3
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, DataSub)
         assert dataclasses.asdict(init.data) == {"p1": 3, "p2": "x"}
 
     with subtests.test("empty init_args"):
         config = {"class_path": f"{__name__}.DataSub", "init_args": {}}
         cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, DataSub)
         assert dataclasses.asdict(init.data) == {"p1": 2, "p2": "-"}
 
     with subtests.test("class_path"):
         cfg = parser.parse_args(["--data=DataSub"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, DataSub)
         assert dataclasses.asdict(init.data) == {"p1": 2, "p2": "-"}
 
@@ -910,7 +910,7 @@ def test_add_argument_dataclass_single_type_subclasses_enabled(parser, subclass_
 
     config = {"class_path": f"{__name__}.DataSub", "init_args": {"p2": "y"}}
     cfg = parser.parse_args([f"--data={json.dumps(config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data, DataSub)
     assert dataclasses.asdict(init.data) == {"p1": 2, "p2": "y"}
     dump = json_or_yaml_load(parser.dump(cfg))["data"]
@@ -989,7 +989,7 @@ def test_dataclass_nested_subclasses_enabled(parser, enable_subclasses):
     assert dump["class_path"] == f"{__name__}.ParentData"
     assert dump["init_args"]["data"] == {"class_path": f"{__name__}.DataSub", "init_args": {"p1": 3, "p2": "x"}}
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.parent, ParentData)
     assert isinstance(init.parent.data, DataSub)
     assert dataclasses.asdict(init.parent.data) == {"p1": 3, "p2": "x"}

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -275,6 +275,20 @@ def test_instantiate_subclasses():
     assert isinstance(cfg_init["cal"], Calendar)
 
 
+def test_instantiate_classes():
+    parser = ArgumentParser(exit_on_error=False)
+    parser.add_argument("--cal", type=Calendar)
+    cfg = parser.parse_object({"cal": {"class_path": "calendar.Calendar"}})
+    with catch_warnings(record=True) as w:
+        cfg_init = parser.instantiate_classes(cfg)
+    assert_deprecation_warn(
+        w,
+        message="``instantiate_classes`` was deprecated",
+        code="cfg_init = parser.instantiate_classes(cfg)",
+    )
+    assert isinstance(cfg_init["cal"], Calendar)
+
+
 def function(a1: float):
     return a1
 
@@ -480,7 +494,14 @@ def test_parse_as_dict(tmp_cwd):
     assert {} == parser.parse_string("{}")
     assert {} == parser.parse_object({})
     assert {} == parser.parse_path("config.json")
-    assert {} == parser.instantiate_classes({})
+    with catch_warnings(record=True) as w:
+        result = parser.instantiate_classes({})
+    assert {} == result
+    assert_deprecation_warn(
+        w,
+        message="``instantiate_classes`` was deprecated",
+        code="result = parser.instantiate_classes({})",
+    )
     assert "{}\n" == parser.dump({})
     parser.save({}, "config.yaml")
     with open("config.yaml") as f:
@@ -839,7 +860,7 @@ def test_add_dataclass_arguments(parser, subtests):
         assert dataclasses.asdict(DataClassA()) == dump["a"]
 
     with subtests.test("instantiate_classes"):
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init["a"], DataClassA)
 
     with subtests.test("docstrings in help"):

--- a/jsonargparse_tests/test_final_classes.py
+++ b/jsonargparse_tests/test_final_classes.py
@@ -26,7 +26,7 @@ def test_add_class_final(parser):
     cfg = parser.parse_args(['--b.b2={"a2": 6.7}'])
     assert cfg.b.b2 == Namespace(a1=1, a2=6.7)
     assert cfg == parser.parse_string(parser.dump(cfg))
-    cfg = parser.instantiate_classes(cfg)
+    cfg = parser.instantiate(cfg)
     assert isinstance(cfg["b"], NotFinalClass)
     assert isinstance(cfg["b"].b2, FinalClass)
 

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -337,7 +337,7 @@ def test_on_parse_add_subclass_arguments_with_instantiate_false(parser, subtests
         assert cfg.c == cfg.f.init_args.c
 
     with subtests.test("class instantiation"):
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.c, Namespace)
         assert isinstance(init.f, ClassF)
         assert isinstance(init.f.c, Calendar)
@@ -384,7 +384,7 @@ def test_on_parse_add_subclass_arguments_compute_fn_return_dict(parser):
     assert cfg.d.init_args.a1 == c_value
     assert cfg.d.init_args.a2 == c_value
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.d, ClassD)
     assert isinstance(init.c, Calendar)
 
@@ -413,7 +413,7 @@ def test_on_parse_within_subcommand(parser, subparser):
     cfg = parser.parse_args(["cmd", "--b=2"])
     assert cfg["cmd"]["foo"].as_dict() == {"a": 2}
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init["cmd"]["foo"], Foo)
 
 
@@ -526,7 +526,7 @@ def test_on_parse_list_of_instances_target(parser):
         Namespace(class_path=f"{__name__}.Field", init_args=Namespace(name="f2")),
     ]
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.data.fields, list)
     assert len(init.data.fields) == 2
     assert all(isinstance(f, Field) for f in init.data.fields)
@@ -583,7 +583,7 @@ def test_on_instantiate_link_instance_attribute():
     cfg = parser.parse_args([])
     assert "x1" not in cfg.x
     assert "y3" not in cfg.y
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.x.x1 == 6
     assert init.y.y3 == '"8"'
 
@@ -593,7 +593,7 @@ def test_on_instantiate_link_all_group_arguments():
     parser.link_arguments("y.y1", "x.x2", apply_on="instantiate")
     cfg = parser.parse_args([])
     assert "x" not in cfg
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init["x"].x1 == 6
     assert init["x"].x2 == 7
     help_str = get_parser_help(parser)
@@ -622,7 +622,7 @@ def test_on_instantiate_failing_compute_fn(parser):
 
     with pytest.raises(ValueError) as ctx:
         cfg = parser.parse_args([])
-        parser.instantiate_classes(cfg)
+        parser.instantiate(cfg)
     ctx.match("Call to compute_fn of link 'to_str.*failed: value is empty")
 
 
@@ -634,7 +634,7 @@ def test_on_instantiate_link_from_subclass_with_compute_fn():
             f"--y={__name__}.ClassY",
         ]
     )
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.x.x1 == 6
 
 
@@ -652,7 +652,7 @@ def test_on_parse_and_instantiate_link_entire_instance(parser):
 
     cfg = parser.parse_args(["--firstweekday=2"])
     assert cfg == Namespace(c=Namespace(firstweekday=2), firstweekday=2)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.n, Namespace)
     assert isinstance(init.c, Calendar)
     assert init.c is init.n.calendar
@@ -674,7 +674,7 @@ def test_on_instantiate_link_multi_source(parser):
 
     cfg = parser.parse_args([])
     assert cfg.as_dict() == {"c": {"one": {"firstweekday": 0}, "two": {"firstweekday": 0}}}
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.c.one, Calendar)
     assert isinstance(init.c.two, TextCalendar)
     assert init.m.calendars == [init.c.one, init.c.two]
@@ -698,7 +698,7 @@ def test_on_instantiate_link_object_in_attribute(parser):
     cfg = parser.parse_args(["--p.firstweekday=2", "--q.q2=3"])
     assert cfg.p == Namespace(firstweekday=2)
     assert cfg.q == Namespace(q2=3)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.p.calendar is init.q.calendar
     assert init.q.calendar.firstweekday == 2
 
@@ -748,7 +748,7 @@ def test_on_instantiate_subclass_link_ignored_missing_param(parser, caplog):
     parser.link_arguments("v.init_args.v1", "w.init_args.w2", apply_on="instantiate")
 
     cfg = parser.parse_args([f"--v={__name__}.ClassV", f"--w={__name__}.ClassW"])
-    parser.instantiate_classes(cfg)
+    parser.instantiate(cfg)
     assert "'v.init_args.v2 --> w.init_args.w1' ignored since attribute" in caplog.text
     assert "'v.init_args.v1 --> w.init_args.w2' ignored since target" in caplog.text
 
@@ -778,7 +778,7 @@ def test_on_instantiate_add_argument_subclass_required_params(parser):
     parser.add_argument("--cls2", type=RequiredTarget)
     parser.link_arguments("cls1.a", "cls2.init_args.a", apply_on="instantiate")
     cfg = parser.parse_args(["--cls1=RequiredSource", "--cls1.a=1", "--cls2=RequiredTarget", "--cls2.b=SubRequired"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls1, RequiredSource)
     assert isinstance(init.cls2, RequiredTarget)
     assert isinstance(init.cls2.b, SubRequired)
@@ -839,7 +839,7 @@ def test_on_instantiate_within_deep_subclass(parser, caplog):
     )
 
     cfg = parser.parse_args([f"--cfg={json.dumps(within_deep_config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.model, WithinDeepModel)
     assert isinstance(init.model.encoder, WithinDeepSource)
     assert isinstance(init.model.decoder, WithinDeepTarget)
@@ -873,7 +873,7 @@ def test_on_instantiate_within_deeper_subclass(parser, caplog):
     )
 
     cfg = parser.parse_args([f"--cfg={json.dumps(within_deeper_config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.system, WithinDeeperSystem)
     assert isinstance(init.system.model, WithinDeepModel)
     assert isinstance(init.system.model.encoder, WithinDeepSource)
@@ -944,7 +944,7 @@ def test_on_instantiate_targets_share_parent(parser):
     )
     parser.link_arguments("source_b.attr_b", "root.child.init_args.param_child", apply_on="instantiate")
     cfg = parser.parse_args([f"--config={json.dumps(config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.source_a, SourceA)
     assert isinstance(init.source_b, SourceB)
     assert isinstance(init.root, HierarchyRoot)
@@ -985,7 +985,7 @@ def test_on_instantiate_targets_passed_to_instantiator(parser):
     parser.add_instantiator(custom_instantiator, Model, subclasses=True)
 
     cfg = parser.parse_args(["--data=Dataloader", "--model=Model", "--model.label=ok"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
 
     assert isinstance(init.data, Dataloader)
     assert init.data.applied_instantiation_links == {}
@@ -1014,7 +1014,7 @@ def test_on_instantiate_target_entire_dataclass(parser, tmp_cwd):
     assert defaults == Namespace(data=Namespace(param=1), container=Namespace(ref=""))
     cfg = parser.parse_args(["--data.param=2", "--container.ref=x"])
     assert cfg == Namespace(data=Namespace(param=2), container=Namespace(ref="x"))
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.data is init.container.dep
     assert init.container.dep.param == 2
 
@@ -1218,7 +1218,7 @@ def test_on_instantiate_linking_deep_targets(parser, tmp_path):
     parser.link_arguments("c", "b.init_args.a.init_args.d", compute_fn=DeepC.fn, apply_on="instantiate")
 
     config = parser.parse_args([f"--config={config_path}"])
-    config_init = parser.instantiate_classes(config)
+    config_init = parser.instantiate(config)
     assert isinstance(config_init["b"].a.d, DeepD)
 
 
@@ -1255,10 +1255,10 @@ def test_on_instantiate_linking_deep_targets_mapping(parser, tmp_path):
     )
 
     config = parser.parse_args([f"--config={config_path}"])
-    config_init = parser.instantiate_classes(config)
+    config_init = parser.instantiate(config)
     assert isinstance(config_init["b"].a_map["name"].d, DeepD)
 
-    config_init = parser.instantiate_classes(config)
+    config_init = parser.instantiate(config)
     assert isinstance(config_init["b"].a_map["name"].d, DeepD)
 
 
@@ -1279,7 +1279,7 @@ def test_on_instantiate_linking_deep_targets_undefined_parent(parser, tmp_path):
     parser.link_arguments("c", "b.init_args.a.init_args.d", compute_fn=DeepC.fn, apply_on="instantiate")
 
     config = parser.parse_args([f"--config={config_path}"])
-    config_init = parser.instantiate_classes(config)
+    config_init = parser.instantiate(config)
     assert isinstance(config_init["b"], DeepBSuper)
 
 
@@ -1305,6 +1305,6 @@ def test_on_instantiate_linking_deep_targets_multiple(parser):
     parser.link_arguments("Source.a", "Node.init_args.sub_class.init_args.a", apply_on="instantiate")
     parser.link_arguments("Source.a", "Node.init_args.sub_class.init_args.b", apply_on="instantiate")
     cfg = parser.parse_args(["--Node=Node", "--Node.init_args.sub_class=DeepTarget"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert 1 == init.Node.sub_class.a
     assert 1 == init.Node.sub_class.b

--- a/jsonargparse_tests/test_paths.py
+++ b/jsonargparse_tests/test_paths.py
@@ -575,7 +575,7 @@ def test_enable_path_subclass(parser, tmp_cwd):
 
     parser.add_argument("--cal", type=Calendar, enable_path=True)
     cfg = parser.parse_args(["--cal=cal.yaml"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init["cal"], Calendar)
 
 

--- a/jsonargparse_tests/test_pydantic.py
+++ b/jsonargparse_tests/test_pydantic.py
@@ -121,11 +121,11 @@ class TestPydantic2Annotated:
         parser.add_argument("--model", type=PingPongTask)
         cfg = parser.parse_args(["--model.type=pong"])
         assert cfg.model == Namespace(type="pong")
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.model, PongTask)
         cfg = parser.parse_args(["--model.type=ping", "--model.attr=abc"])
         assert cfg.model == Namespace(type="ping", attr="abc")
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.model, PingTask)
 
 
@@ -216,7 +216,7 @@ class TestPydanticBasics:
         parser.add_argument("--model", type=PydanticSubModel, default=PydanticSubModel(p1="a"))
         cfg = parser.parse_args(["--model.p3=0.2"])
         assert Namespace(p1="a", p2=3, p3=0.2) == cfg.model
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.model, PydanticSubModel)
 
     def test_field_default_factory(self, parser):
@@ -272,7 +272,7 @@ class TestPydanticBasics:
         cfg = parser.parse_args([])
         assert cfg == Namespace()
 
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert init.data.p1 == "-"
 
     @pytest.mark.skipif(not pydantic_supports_field_init, reason="Field.init is required")
@@ -281,7 +281,7 @@ class TestPydanticBasics:
         assert parser.get_defaults() == Namespace()
         cfg = parser.parse_args([])
         assert cfg == Namespace()
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.data, ParentPydanticDataFieldInitFalse)
         assert isinstance(init.data.y, PydanticDataFieldInitFalse)
         assert init.data.y.p1 == "-"
@@ -330,7 +330,7 @@ class TestPydanticBasics:
         }
         cfg = parser.parse_args(["--model", json.dumps(model)])
         assert cfg.model.nested["key"] == Namespace(inputs=["a", "b"], outputs=["x", "y"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.model, PydanticNestedDict)
         assert isinstance(init.model.nested["key"], NestedModel)
 
@@ -411,7 +411,7 @@ def test_model_argument_subclasses_enabled(parser, subtests, enable_subclasses):
 
     with subtests.test("sub-param"):
         cfg = parser.parse_args(["--person.pets.name=lucky"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.person, Person)
         assert isinstance(init.person.pets[0], SpecialCat)
         assert isinstance(init.person.pets[1], Dog)

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -146,7 +146,7 @@ def test_add_class_nested_as_group_false(parser):
         assert find_action(parser, f"g.{key}") is None, f"{key} should not be in parser but is"
 
     defaults = parser.get_defaults()
-    assert defaults == parser.instantiate_classes(defaults)
+    assert defaults == parser.instantiate(defaults)
 
 
 def test_add_class_default_group_title(parser):
@@ -189,7 +189,7 @@ def test_add_class_without_parameters(parser):
 
     cfg = parser.parse_args([])
     assert "no_params" not in cfg
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.no_params, NoParams)
 
     config = {"no_params": {"class_path": f"{__name__}.NoParams"}}
@@ -214,7 +214,7 @@ def test_add_class_nested_with_and_without_parameters(parser):
     cfg = parser.parse_args(["--group.first.p1=2"])
     assert cfg.group.first == Namespace(p1=2)
     assert "group.second" not in cfg
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.group.first, NestedWithParams)
     assert isinstance(init.group.second, NestedWithoutParams)
 
@@ -252,7 +252,7 @@ def test_add_class_group_name_dash_required_parameters(parser):
     parser.add_class_arguments(RequiredParams, "required-params")
     assert "required-params" in parser.groups
     cfg = parser.parse_args(["--required-params.n=6", "--required-params.m=0.9"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.required_params, RequiredParams)
     assert init.required_params.n == 6
     assert init.required_params.m == 0.9
@@ -287,13 +287,13 @@ def test_add_class_conditional_kwargs(parser):
 
     cfg = parser.parse_args(["--g.func=1", "--g.kmg2=x"])
     assert cfg.g == Namespace(func="1", kmg1=1, kmg2="x")
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     init.g._run()
     assert init.g.called == "method1"
 
     cfg = parser.parse_args(["--g.func=2", "--g.kmg4=5"])
     assert cfg.g == Namespace(func="2", kmg1=1, kmg4=5)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     init.g._run()
     assert init.g.called == "method2"
 
@@ -353,7 +353,7 @@ def test_add_class_in_subcommand(parser, subparser):
 
     cfg = parser.parse_args(["cmd"])
     assert cfg.subcommand == "cmd"
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init["cmd"]["class"], WithinSubcommand)
     assert init["cmd"]["class"].a == 1
 
@@ -405,7 +405,7 @@ def test_add_class_custom_instantiator(parser):
     parser.add_class_arguments(Class0, "a")
     parser.add_instantiator(instantiate, Class0)
     cfg = parser.parse_args([])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.a, Class0)
     assert init.a.call == "custom"
 
@@ -435,7 +435,7 @@ def test_add_class_unmatched_default_type(parser):
     parser.add_class_arguments(UnmatchedDefaultType, "cls")
     cfg = parser.parse_args(["--cls.p1=x"])
     assert cfg.cls == Namespace(p1="x", p2="deprecated")
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.cls.p2 == "deprecated"
     dump = parser.dump(cfg)
     assert json_or_yaml_load(dump) == {"cls": {"p1": "x", "p2": "deprecated"}}
@@ -463,7 +463,7 @@ def test_add_class_and_action_parser(parser, subparser):
         }
     }
     cfg = parser.parse_args([f"--config={json.dumps(config)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert list(cfg.keys()) == ["nested.deep.leaf.p1", "nested.deep.leaf.p2", "config"]
     assert list(init.keys()) == ["nested.deep.leaf", "config"]
     assert isinstance(init.nested.deep.leaf, LeafClass)

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -42,11 +42,11 @@ def test_subclass_basics(parser, type):
     }
     parser.add_argument("--op", type=type)
     cfg = parser.parse_args([f"--op={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init["op"], Calendar)
     assert 3 == init["op"].firstweekday
 
-    init = parser.instantiate_classes(parser.parse_args([]))
+    init = parser.instantiate(parser.parse_args([]))
     assert init["op"] is None
 
 
@@ -105,7 +105,7 @@ def test_subclass_within_class_instantiate(parser):
     assert cfg.c1.class_path == f"{__name__}.Instantiate1"
     assert cfg.c1.init_args == Namespace(a1=7, a2=2.3)
 
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.c1, Instantiate1)
     assert 7 == init.c1.a1
     assert 2.3 == init.c1.a2
@@ -139,14 +139,14 @@ def test_subclass_optional_list(parser, subtests):
         assert cfg.as_dict()["op"] == expected
         cfg = parser.parse_args(['--op=["calendar.Calendar"]'])
         assert cfg.as_dict()["op"] == expected
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.op[0], Calendar)
 
     with subtests.test("with init_args"):
         init_args = '"init_args": {"firstweekday": 3}'
         cfg = parser.parse_args(["--op=[{" + class_path + ", " + init_args + "}]"])
         assert cfg["op"][0]["init_args"].as_dict() == {"firstweekday": 3}
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init["op"][0], Calendar)
         assert 3 == init["op"][0].firstweekday
 
@@ -357,7 +357,7 @@ def test_class_method_instantiator(parser):
     cfg = parser.parse_args([f"--cls={__name__}.ClassMethodInstantiator.from_p1", "--cls.p1=2"])
     assert cfg.cls.class_path == f"{__name__}.ClassMethodInstantiator.from_p1"
     assert cfg.cls.init_args == Namespace(p1=2)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, ClassMethodInstantiator)
     assert init.cls.p1 == 2
     assert init.cls.p2 is False
@@ -386,7 +386,7 @@ def test_function_instantiator(parser):
     cfg = parser.parse_args([f"--cls={__name__}.function_instantiator", "--cls.p2=y"])
     assert cfg.cls.class_path == f"{__name__}.function_instantiator"
     assert cfg.cls.init_args == Namespace(p2="y")
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, FunctionInstantiator)
     assert init.cls.p1 == 1.0
     assert init.cls.p2 == "y"
@@ -452,7 +452,7 @@ def test_custom_instantiation_argument_type(parser):
     parser.add_argument("--cls", type=CustomInstantiationBase)
     parser.add_instantiator(instantiator("argument type"), CustomInstantiationBase)
     cfg = parser.parse_args(["--cls=CustomInstantiationBase"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, CustomInstantiationBase)
     assert init.cls.call == "argument type"
 
@@ -461,7 +461,7 @@ def test_custom_instantiation_unused_for_subclass(parser):
     parser.add_argument("--cls", type=CustomInstantiationBase)
     parser.add_instantiator(instantiator("base"), CustomInstantiationBase, subclasses=False)
     cfg = parser.parse_args(["--cls=CustomInstantiationSub"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, CustomInstantiationSub)
     assert not hasattr(init.cls, "call")
 
@@ -470,7 +470,7 @@ def test_custom_instantiation_used_for_subclass(parser):
     parser.add_argument("--cls", type=CustomInstantiationBase)
     parser.add_instantiator(instantiator("subclass"), CustomInstantiationBase, subclasses=True)
     cfg = parser.parse_args(["--cls=CustomInstantiationSub"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, CustomInstantiationSub)
     assert init.cls.call == "subclass"
 
@@ -481,7 +481,7 @@ def test_custom_instantiation_prepend(parser):
     parser.add_instantiator(instantiator("prepended"), CustomInstantiationBase, subclasses=True, prepend=True)
     assert len(parser._instantiators) == 2
     cfg = parser.parse_args(["--cls=CustomInstantiationSub"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, CustomInstantiationSub)
     assert init.cls.call == "prepended"
 
@@ -505,7 +505,7 @@ def test_custom_instantiation_nested(parser):
     parser.add_argument("--cls", type=CustomInstantiationNested)
     parser.add_instantiator(instantiator("nested"), CustomInstantiationBase, subclasses=True)
     cfg = parser.parse_args(["--cls=CustomInstantiationNested", "--cls.sub=CustomInstantiationSub"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, CustomInstantiationNested)
     assert isinstance(init.cls.sub, CustomInstantiationSub)
     assert init.cls.sub.call == "nested"
@@ -720,7 +720,7 @@ def test_subclass_mapping_parameter(parser, subtests):
         assert cfg.b.int_list == [1]
 
     with subtests.test("instantiate"):
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.b, MappingParamB)
         assert isinstance(init.b.class_map, dict)
         assert isinstance(init.b.class_map["one"], MappingParamA)
@@ -883,7 +883,7 @@ def test_type_any_subclasses(parser):
     }
 
     cfg = parser.parse_args([f"--any={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.any, AnySubclasses)
     assert isinstance(init.any.cal1, TextCalendar)
     assert isinstance(init.any.cal2, HTMLCalendar)
@@ -894,7 +894,7 @@ def test_type_any_subclasses(parser):
     cfg = parser.parse_args([f"--any={json.dumps(value)}"])
     assert isinstance(cfg.any.init_args.cal1, Namespace)
     assert isinstance(cfg.any.init_args.cal2, dict)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.any, AnySubclasses)
     assert isinstance(init.any.cal1, TextCalendar)
     assert isinstance(init.any.cal2, dict)
@@ -920,7 +920,7 @@ def test_type_any_list_of_subclasses(parser):
     ]
 
     cfg = parser.parse_args([f"--any={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.any, list)
     assert 2 == len(init.any)
     assert isinstance(init.any[0], TextCalendar)
@@ -943,7 +943,7 @@ def test_type_any_dict_of_subclasses(parser):
     }
 
     cfg = parser.parse_args([f"--any={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.any, dict)
     assert 2 == len(init.any)
     assert isinstance(init.any["k1"], TextCalendar)
@@ -1089,7 +1089,7 @@ def test_subclass_discard_init_args_with_default_config_files(parser, tmp_cwd, l
     parser.default_config_files = [config_path]
     parser.add_argument("--cal", type=Optional[Calendar])
 
-    init = parser.instantiate_classes(parser.get_defaults())
+    init = parser.instantiate(parser.get_defaults())
     assert isinstance(init.cal, OverrideDefaultConfig)
 
     parser.logger = logger
@@ -1098,7 +1098,7 @@ def test_subclass_discard_init_args_with_default_config_files(parser, tmp_cwd, l
     assert "discarding init_args: {'param': '1'}" in logs.getvalue()
     assert cfg.cal.init_args == Namespace(firstweekday=3)
     with capture_logs(logger) as logs:
-        assert type(parser.instantiate_classes(cfg).cal) is Calendar
+        assert type(parser.instantiate(cfg).cal) is Calendar
     assert logs.getvalue()
 
 
@@ -1185,7 +1185,7 @@ def test_discard_init_args_config_nested(parser, logger, tmp_cwd, method):
         cfg = parser.parse_args([f"--cfg={config_path}"])
     assert "discarding init_args: {'s1': 'x'}" in logs.getvalue()
     with capture_logs(logger) as logs:
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
     assert logs.getvalue()
     assert isinstance(init.main, ConfigDiscardMain)
     assert isinstance(init.main.sub, ConfigDiscardSub2)
@@ -1238,7 +1238,7 @@ def test_subclass_discard_init_args_dict_looks_like_subclass(parser, logger, tmp
         cfg = parser.parse_args([f"--cfg={config_paths[1]}", f"--cfg={config_paths[2]}"])
     assert "discarding init_args: {'s1': 1}" in logs.getvalue()
     with capture_logs(logger) as logs:
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
     assert logs.getvalue()
     assert isinstance(init.main, DictDiscardMain)
     assert isinstance(init.main.sub, dict)
@@ -1283,7 +1283,7 @@ def test_subclass_unresolved_parameters(parser, subtests):
     with subtests.test("config"):
         cfg = parser.parse_args([f"--cfg={json.dumps(config)}"])
         assert cfg.cls == expected
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.cls, UnresolvedParams)
         assert init.cls.kwargs == expected.dict_kwargs
 
@@ -1362,12 +1362,12 @@ def test_add_subclass_tuple(parser):
 
     cfg = parser.parse_args(['--c={"class_path": "TupleBaseA", "init_args": {"a1": -1}}'])
     assert cfg.c.init_args.a1 == -1
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.c, TupleBaseA)
 
     cfg = parser.parse_args(['--c={"class_path": "TupleBaseB", "init_args": {"b1": -4.5}}'])
     assert cfg.c.init_args.b1 == -4.5
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.c, TupleBaseB)
 
     help_str = get_parse_args_stdout(parser, [f"--c.help={__name__}.TupleBaseB"])
@@ -1387,7 +1387,7 @@ def test_add_subclass_not_required_group(parser):
     parser.add_subclass_arguments(Calendar, "cal", required=False)
     cfg = parser.parse_args([])
     assert cfg == Namespace(cal=None)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init == Namespace(cal=None)
 
 
@@ -1451,7 +1451,7 @@ def test_subclass_signature_instance_default(parser):
         parser.add_class_arguments(InstanceDefault)
     cfg = parser.parse_args([])
     assert isinstance(cfg["cal"], Calendar)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init["cal"] is cfg["cal"]
     with warnings.catch_warnings(record=True) as w:
         dump = parser.dump(cfg)
@@ -1531,7 +1531,7 @@ def test_parse_implements_protocol(parser):
     cfg = parser.parse_args([f"--cls={__name__}.ImplementsInterface", "--cls.batch_size=5"])
     assert cfg.cls.class_path == f"{__name__}.ImplementsInterface"
     assert cfg.cls.init_args == Namespace(batch_size=5)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, ImplementsInterface)
     assert init.cls.batch_size == 5
     assert init.cls.predict([1.0, 2.0]) == [1.0, 2.0]
@@ -1602,7 +1602,7 @@ def test_parse_implements_callable_protocol(parser):
     cfg = parser.parse_args([f"--cls={__name__}.ImplementsCallableInterface", "--cls.batch_size=7"])
     assert cfg.cls.class_path == f"{__name__}.ImplementsCallableInterface"
     assert cfg.cls.init_args == Namespace(batch_size=7)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.cls, ImplementsCallableInterface)
     assert init.cls([1.0, 2.0]) == [1.0, 2.0]
 

--- a/jsonargparse_tests/test_subcommands.py
+++ b/jsonargparse_tests/test_subcommands.py
@@ -351,7 +351,7 @@ def test_subcommand_default_config_add_subdefaults(parser, subparser, tmp_cwd):
     assert list(cfg.fit.model.init_args.__dict__) == ["submodel"]
     assert cfg.fit.model.init_args.submodel.class_path == f"{__name__}.SubModel"
     assert cfg.fit.model.init_args.submodel.init_args == Namespace(p1=1, p2="-")
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.fit.model, Model)
     assert isinstance(init.fit.model.submodel, SubModel)
 
@@ -430,14 +430,14 @@ def test_subcommands_custom_instantiator(parser, subparser, subtests):
     with subtests.test("main parser"):
         parser.add_instantiator(instantiator("main parser"), CustomInstantiationBase)
         cfg = parser.parse_args(["cmd", "--cls", "CustomInstantiationBase"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.cmd.cls, CustomInstantiationBase)
         assert init.cmd.cls.call == "main parser"
 
     with subtests.test("subparser"):
         subparser.add_instantiator(instantiator("subparser"), CustomInstantiationBase)
         cfg = parser.parse_args(["cmd", "--cls", "CustomInstantiationBase"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         assert isinstance(init.cmd.cls, CustomInstantiationBase)
         assert init.cmd.cls.call == "subparser"
 

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -955,7 +955,7 @@ def test_callable_class_path_simple(parser):
     cfg = parser.parse_args([f"--callable={json.dumps(value)}"])
     assert value == cfg.callable.as_dict()
     assert value == json_or_yaml_load(parser.dump(cfg))["callable"]
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.callable, CallableClassPath)
     assert 2 == init.callable()
 
@@ -991,7 +991,7 @@ def test_callable_class_path_short_init_args(parser, callable_type):
     cfg = parser.parse_args([f"--call={__name__}.CallableGiveName", "--call.name=Bob"])
     assert cfg.call.class_path == f"{__name__}.CallableGiveName"
     assert cfg.call.init_args == Namespace(name="Bob")
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert init.call() == "Bob"
 
 
@@ -1052,7 +1052,7 @@ def test_callable_args_return_type_class(parser, subtests):
     with subtests.test("default"):
         cfg = parser.get_defaults()
         assert cfg.optimizer.class_path == f"{__name__}.SGD"
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer([0.1, 2, 3])
         assert isinstance(optimizer, SGD)
         assert [0.1, 2, 3] == optimizer.params
@@ -1069,7 +1069,7 @@ def test_callable_args_return_type_class(parser, subtests):
         cfg = parser.parse_args([f"--optimizer={json.dumps(value)}"])
         assert f"{__name__}.Adam" == cfg.optimizer.class_path
         assert Namespace(lr=0.01, momentum=0.0) == cfg.optimizer.init_args
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer([4.5, 6.7])
         assert isinstance(optimizer, Adam)
         assert [4.5, 6.7] == optimizer.params
@@ -1108,7 +1108,7 @@ def test_callable_protocol_instance_factory(parser, subtests):
     with subtests.test("default"):
         cfg = parser.get_defaults()
         assert cfg.optimizer.class_path == f"{__name__}.SGD"
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer(params=[1, 2])
         assert isinstance(optimizer, SGD)
         assert optimizer.params == [1, 2]
@@ -1124,7 +1124,7 @@ def test_callable_protocol_instance_factory(parser, subtests):
             },
         }
         cfg = parser.parse_args([f"--optimizer={json.dumps(value)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer(params=[3, 2, 1])
         assert isinstance(optimizer, Adam)
         assert optimizer.params == [3, 2, 1]
@@ -1140,7 +1140,7 @@ def test_callable_protocol_instance_factory(parser, subtests):
             },
         }
         cfg = parser.parse_args([f"--optimizer={json.dumps(value)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer(params=[3, 2])
         assert isinstance(optimizer, DifferentParamsOrder)
         assert optimizer.params == [3, 2]
@@ -1173,7 +1173,7 @@ def test_callable_protocol_instance_factory_with_positional(parser):
         },
     }
     cfg = parser.parse_args([f"--optimizer={json.dumps(value)}"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     optimizer = init.optimizer(0.2, params=[0, 1])
     assert optimizer.lr == 0.2
     assert optimizer.params == [0, 1]
@@ -1206,7 +1206,7 @@ def test_callable_multiple_args_return_type_class(parser, subtests):
 
     with subtests.test("default"):
         cfg = parser.get_defaults()
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer([0.1, 2, 3], 1e-3)
         assert isinstance(optimizer, SGD)
         assert [0.1, 2, 3] == optimizer.params
@@ -1221,7 +1221,7 @@ def test_callable_multiple_args_return_type_class(parser, subtests):
         cfg = parser.parse_args([f"--optimizer={json.dumps(value)}"])
         assert f"{__name__}.Adam" == cfg.optimizer.class_path
         assert Namespace(momentum=0.9) == cfg.optimizer.init_args
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         optimizer = init.optimizer([4.5, 6.7], 0.01)
         assert isinstance(optimizer, Adam)
         assert [4.5, 6.7] == optimizer.params
@@ -1283,7 +1283,7 @@ def test_add_class_arguments_skip_callable_init_arg_and_partial_skip(parser):
     with pytest.raises(ArgumentError):
         parser.parse_args(["--optimizer=Adam", "--optimizer.momentum=0.9"])
 
-    init = parser.instantiate_classes(parser.parse_args(["--optimizer=Adam"]))
+    init = parser.instantiate(parser.parse_args(["--optimizer=Adam"]))
     optimizer = init.optimizer([1.2], 0.2)
     assert isinstance(optimizer, Adam)
     assert optimizer.params == [1.2]
@@ -1314,7 +1314,7 @@ def test_callable_args_return_type_union_of_classes(parser, subtests):
 
     with subtests.test("default"):
         cfg = parser.get_defaults()
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         scheduler = init.scheduler(optimizer)
         assert isinstance(scheduler, StepLR)
         assert scheduler.optimizer is optimizer
@@ -1330,7 +1330,7 @@ def test_callable_args_return_type_union_of_classes(parser, subtests):
         cfg = parser.parse_args([f"--scheduler={json.dumps(value)}"])
         assert f"{__name__}.ReduceLROnPlateau" == cfg.scheduler.class_path
         assert Namespace(monitor="loss", factor=0.1) == cfg.scheduler.init_args
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         scheduler = init.scheduler(optimizer)
         assert isinstance(scheduler, ReduceLROnPlateau)
         assert scheduler.optimizer is optimizer
@@ -1355,7 +1355,7 @@ def test_optional_callable_args_return_type_class(parser, subtests):
 
     with subtests.test("default"):
         cfg = parser.get_defaults()
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         scheduler = init.scheduler(optimizer)
         assert isinstance(scheduler, StepLR)
         assert scheduler.last_epoch == 1
@@ -1369,7 +1369,7 @@ def test_optional_callable_args_return_type_class(parser, subtests):
             },
         }
         cfg = parser.parse_args([f"--scheduler={json.dumps(value)}"])
-        init = parser.instantiate_classes(cfg)
+        init = parser.instantiate(cfg)
         scheduler = init.scheduler(optimizer)
         assert isinstance(scheduler, StepLR)
         assert scheduler.last_epoch == 2
@@ -1399,7 +1399,7 @@ def test_callable_args_return_type_class_subconfig(parser, tmp_cwd):
     parser.add_class_arguments(CallableSubconfig, "m", sub_configs=True)
     cfg = parser.parse_args(["--m.o=optimizer.yaml"])
     assert cfg.m.o.class_path == f"{__name__}.Adam"
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     optimizer = init.m.o(1)
     assert isinstance(optimizer, Adam)
     assert optimizer.momentum == 0.8
@@ -1413,7 +1413,7 @@ def test_callable_args_pickleable(parser, tmp_cwd):
     Path("optimizer.yaml").write_text(json_or_yaml_dump(config))
     parser.add_class_arguments(CallableSubconfig, "m", sub_configs=True)
     cfg = parser.parse_args(["--m.o=optimizer.yaml"])
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
 
     filepath = str(tmp_cwd) + "/pickled.pkl"
     with open(filepath, "wb") as f:
@@ -1443,7 +1443,7 @@ def test_callable_zero_args_return_type_class(parser):
     assert cfg.model.activation == Namespace(
         class_path=f"{__name__}.LeakyReLU", init_args=Namespace(negative_slope=0.05)
     )
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.model, Model)
     assert not isinstance(init.model.activation, Module)
     activation = init.model.activation()

--- a/jsonargparse_tests/test_typing.py
+++ b/jsonargparse_tests/test_typing.py
@@ -562,7 +562,7 @@ def test_add_class_from_function_arguments(parser):
 
     cfg = parser.parse_args(["--a.a1=v", "--a.a2=3"])
     assert cfg.a == Namespace(a1="v", a2=3)
-    init = parser.instantiate_classes(cfg)
+    init = parser.instantiate(cfg)
     assert isinstance(init.a, Calendar)
     assert init.a.a1 == "v"
     assert init.a.a2 == 3


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
