### PR TITLE
Deprecate Namespace.{get_sorted_keys,get_value_and_parent} since they are for internal use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ Deprecated
 - ``ArgumentParser.add_instantiator`` is deprecated and will be removed in
   v5.0.0. Use the global function ``jsonargparse.add_instantiator`` instead
   (`#899 <https://github.com/omni-us/jsonargparse/pull/899>`__).
+- ``Namespace.get_sorted_keys`` and ``Namespace.get_value_and_parent`` are
+  deprecated and will be removed in v5.0.0. Instead run ``.keys()`` and then
+  sort or get the parent and leaf separately. (`#900
+  <https://github.com/omni-us/jsonargparse/pull/900>`__).
 
 
 v4.48.0 (2026-04-10)

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -55,6 +55,8 @@ from ._loaders_dumpers import (
 from ._namespace import (
     Namespace,
     NSKeyError,
+    get_non_meta_sorted_keys,
+    get_value_and_parent,
     is_meta_key,
     patch_namespace,
     recreate_branches,
@@ -939,7 +941,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
                 return os.path.basename(val_path)
 
             def save_paths(cfg):
-                for key in cfg.get_sorted_keys():
+                for key in get_non_meta_sorted_keys(cfg):
                     val = cfg[key]
                     if isinstance(val, (Namespace, dict)) and "__path__" in val:
                         if is_path_action(key):
@@ -1156,7 +1158,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
             return missing
 
         def check_values(cfg):
-            sorted_keys = {k: find_action(self, k) for k in cfg.get_sorted_keys()}
+            sorted_keys = {k: find_action(self, k) for k in get_non_meta_sorted_keys(cfg)}
             for key, action in sorted_keys.items():
                 parent_action = None
                 if action is None:
@@ -1261,7 +1263,7 @@ class ArgumentParser(ParserDeprecations, ActionsContainer, ArgumentLinking, Logg
             ActionLink.apply_instantiation_links(self, cfg, target=component.dest)
             if isinstance(component, ActionTypeHint):
                 try:
-                    value, parent, key = cfg.get_value_and_parent(component.dest)
+                    value, parent, key = get_value_and_parent(cfg, component.dest)
                 except (KeyError, AttributeError):
                     pass
                 else:

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -406,7 +406,7 @@ cli_return_parser_message = """
 """
 
 auto_cli_implicit_components_message = """
-    Implicit components discovery in auto_cli was deprecated in v4.48.0 and
+    Implicit components discovery in auto_cli was deprecated in v4.49.0 and
     will be removed in v5.0.0. Pass components explicitly, explicit is better
     than implicit.
 """
@@ -828,6 +828,55 @@ def strip_meta(cfg):
     from ._namespace import remove_meta
 
     return remove_meta(cfg)
+
+
+def is_meta_key(key: str) -> bool:
+    from ._namespace import meta_keys, split_key_leaf
+
+    leaf_key = split_key_leaf(key)[-1]
+    return leaf_key in meta_keys
+
+
+class NamespaceDeprecations:
+    """Helper class for Namespace deprecations. Will be removed in v5.0.0."""
+
+    @deprecated("""
+        get_sorted_keys method was deprecated in v4.49.0 and will be removed in
+        v5.0.0. There is no replacement since this is for internal use and
+        developers can call .keys() and then sort.
+    """)
+    def get_sorted_keys(self, branches: bool = True, key_filter: Callable = is_meta_key) -> list[str]:
+        """Deprecated method"""
+        from ._namespace import split_key
+
+        keys = [k for k in self.keys() if not key_filter(k)]  # type: ignore[attr-defined]
+        if branches:
+            for key in [k for k in keys if "." in k]:
+                key_split = split_key(key)
+                for num in range(len(key_split) - 1):
+                    parent_key = ".".join(key_split[: num + 1])
+                    if parent_key not in keys:
+                        keys.append(parent_key)
+        keys.sort(key=lambda x: -len(split_key(x)))
+        return keys
+
+    @deprecated("""
+        get_value_and_parent method was deprecated in v4.49.0 and will be
+        removed in v5.0.0. There is no replacement since this is for internal
+        use and developers can get the parent and leaf separately.
+    """)
+    def get_value_and_parent(self, key: str) -> tuple[Any, Namespace, str]:
+        """Deprecated method"""
+        leaf_key, parent_ns, _ = self._parse_required_key(key)  # type: ignore[attr-defined]
+        return parent_ns[leaf_key], parent_ns, leaf_key
+
+
+def _patch_namespace_deprecations() -> None:
+    Namespace.get_sorted_keys = NamespaceDeprecations.get_sorted_keys  # type: ignore[attr-defined]
+    Namespace.get_value_and_parent = NamespaceDeprecations.get_value_and_parent  # type: ignore[attr-defined]
+
+
+_patch_namespace_deprecations()
 
 
 class HelpFormatterDeprecations:

--- a/jsonargparse/_namespace.py
+++ b/jsonargparse/_namespace.py
@@ -4,12 +4,7 @@ import argparse
 from collections import OrderedDict
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import (
-    Any,
-    Callable,
-    Optional,
-    Union,
-)
+from typing import Any, Optional, Union
 
 __all__ = ["Namespace"]
 
@@ -232,24 +227,6 @@ class Namespace(argparse.Namespace):
         for _, val in self.items(branches):
             yield val
 
-    def get_sorted_keys(self, branches: bool = True, key_filter: Callable = is_meta_key) -> list[str]:
-        """Returns a list of keys sorted by descending depth.
-
-        Args:
-            branches: Whether to include branch keys instead of only leaves.
-            key_filter: Function that selects keys to exclude.
-        """
-        keys = [k for k in self.keys() if not key_filter(k)]
-        if branches:
-            for key in [k for k in keys if "." in k]:
-                key_split = split_key(key)
-                for num in range(len(key_split) - 1):
-                    parent_key = ".".join(key_split[: num + 1])
-                    if parent_key not in keys:
-                        keys.append(parent_key)
-        keys.sort(key=lambda x: -len(split_key(x)))
-        return keys
-
     def clone(self, with_meta: bool = True) -> "Namespace":
         """Creates an new copy of the nested namespace.
 
@@ -283,16 +260,14 @@ class Namespace(argparse.Namespace):
         return self
 
     def get(self, key: str, default: Any = None) -> Any:
+        """Returns the value for the given key if it exists, otherwise the default."""
         try:
             return self[key]
         except (KeyError, TypeError):
             return default
 
-    def get_value_and_parent(self, key: str) -> tuple[Any, "Namespace", str]:
-        leaf_key, parent_ns, _ = self._parse_required_key(key)
-        return parent_ns[leaf_key], parent_ns, leaf_key
-
     def pop(self, key: str, default: Any = None) -> Any:
+        """Removes the given key and returns its value if it exists, otherwise the default."""
         leaf_key, parent_ns, _ = self._parse_key(key)
         if not parent_ns:
             return default
@@ -329,6 +304,17 @@ def expand_dict(data: dict) -> Namespace:
 def dict_to_namespace(data: dict[str, Any]) -> Namespace:
     data = recreate_branches(data)
     return expand_dict(data)
+
+
+def get_non_meta_sorted_keys(namespace: Namespace) -> list[str]:
+    keys = [k for k in namespace.keys(branches=True) if not is_meta_key(k)]
+    keys.sort(key=lambda x: -len(split_key(x)))
+    return keys
+
+
+def get_value_and_parent(namespace: Namespace, key: str) -> tuple[Any, Namespace, str]:
+    leaf_key, parent_ns, _ = namespace._parse_required_key(key)
+    return parent_ns[leaf_key], parent_ns, leaf_key
 
 
 # Temporal to provide backward compatibility in pytorch-lightning

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -16,7 +16,7 @@ from ._common import (
     is_subclasses_disabled,
 )
 from ._instantiation import get_class_instantiator
-from ._namespace import Namespace
+from ._namespace import Namespace, get_value_and_parent
 from ._optionals import attrs_support, get_doc_short_description, is_attrs_class, is_pydantic_model
 from ._parameter_resolvers import ParamData, get_parameter_origins, get_signature_parameters
 from ._required import set_required
@@ -563,7 +563,7 @@ def get_object_name(obj) -> str:
 
 def group_instantiate_class(group, cfg):
     try:
-        value, parent, key = cfg.get_value_and_parent(group.dest)
+        value, parent, key = get_value_and_parent(cfg, group.dest)
     except KeyError:
         value = {}
         parent = cfg

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -929,6 +929,32 @@ def test_strip_meta():
     assert result == {"x": 1}
 
 
+def test_namespace_get_sorted_keys():
+    ns = Namespace(a=Namespace(b=1))
+    with catch_warnings(record=True) as w:
+        keys = ns.get_sorted_keys()
+    assert keys == ["a.b", "a"]
+    assert_deprecation_warn(
+        w,
+        message="get_sorted_keys method was deprecated",
+        code="keys = ns.get_sorted_keys()",
+    )
+
+
+def test_namespace_get_value_and_parent():
+    ns = Namespace(a=Namespace(b=1))
+    with catch_warnings(record=True) as w:
+        value, parent, key = ns.get_value_and_parent("a.b")
+    assert value == 1
+    assert parent == ns.a
+    assert key == "b"
+    assert_deprecation_warn(
+        w,
+        message="get_value_and_parent method was deprecated",
+        code='value, parent, key = ns.get_value_and_parent("a.b")',
+    )
+
+
 @pytest.mark.skipif(not ruamel_support, reason="ruamel.yaml package is required")
 def test_DefaultHelpFormatter_yaml_comments(parser):
     parser.add_argument("--arg", type=int, help="Description")


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
