### PR TITLE
fix(typehints): handle bare tuple/set and module-form __builtins__

### DIFF
--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -783,8 +783,6 @@ def resolve_forward_ref(ref):
     if not isinstance(ref, ForwardRef) or not ref.__forward_module__:
         return ref
 
-    # __builtins__ is a dict in regular modules but a module in __main__ and
-    # other embedding contexts; handle both forms.
     builtins_obj = __builtins__
     aliases = builtins_obj.copy() if isinstance(builtins_obj, dict) else vars(builtins_obj).copy()
     aliases.update(vars(import_module(ref.__forward_module__)))

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -783,7 +783,10 @@ def resolve_forward_ref(ref):
     if not isinstance(ref, ForwardRef) or not ref.__forward_module__:
         return ref
 
-    aliases = __builtins__.copy()
+    # __builtins__ is a dict in regular modules but a module in __main__ and
+    # other embedding contexts; handle both forms.
+    builtins_obj = __builtins__
+    aliases = builtins_obj.copy() if isinstance(builtins_obj, dict) else vars(builtins_obj).copy()
     aliases.update(vars(import_module(ref.__forward_module__)))
     return aliases.get(ref.__forward_arg__, ref)
 
@@ -1646,7 +1649,11 @@ def sort_subtypes_for_union(subtypes, val, prev_val, append):
 
 
 def is_ellipsis_tuple(typehint):
-    return typehint.__origin__ in {Tuple, tuple} and len(typehint.__args__) > 1 and typehint.__args__[1] == Ellipsis
+    origin = getattr(typehint, "__origin__", None)
+    if origin not in {Tuple, tuple}:
+        return False
+    args = getattr(typehint, "__args__", ())
+    return len(args) > 1 and args[1] == Ellipsis
 
 
 def is_optional(annotation, ref_type=None):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -1657,6 +1657,18 @@ def test_is_ellipsis_tuple_with_subscripted_tuple():
     assert is_ellipsis_tuple(tuple[int, ...]) is True
 
 
+def test_argument_parser_accepts_bare_tuple_typehint(parser):
+    parser.add_argument("--data", type=tuple)
+    cfg = parser.parse_args(["--data=[1, 2]"])
+    assert tuple(cfg.data) == (1, 2)
+
+
+def test_argument_parser_accepts_bare_set_typehint(parser):
+    parser.add_argument("--data", type=set)
+    cfg = parser.parse_args(["--data=[1, 2, 1]"])
+    assert set(cfg.data) == {1, 2}
+
+
 class SkipDefault(Calendar):
     def __init__(self, *args, param: str = "0", **kwargs):
         super().__init__(*args, **kwargs)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -1642,6 +1642,21 @@ def test_is_optional(typehint, ref_type, expected):
     assert expected == is_optional(typehint, ref_type)
 
 
+@pytest.mark.parametrize("bare_type", [tuple, set, list, frozenset])
+def test_is_ellipsis_tuple_accepts_bare_types(bare_type):
+    from jsonargparse._typehints import is_ellipsis_tuple
+
+    assert is_ellipsis_tuple(bare_type) is False
+
+
+def test_is_ellipsis_tuple_with_subscripted_tuple():
+    from jsonargparse._typehints import is_ellipsis_tuple
+
+    assert is_ellipsis_tuple(Tuple[int, ...]) is True
+    assert is_ellipsis_tuple(Tuple[int, str]) is False
+    assert is_ellipsis_tuple(tuple[int, ...]) is True
+
+
 class SkipDefault(Calendar):
     def __init__(self, *args, param: str = "0", **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## What does this PR do?

Fixes two of the crashes reported in #904.

`is_ellipsis_tuple` raised `AttributeError` when called on bare tuple/set/list types (no subscript) because it accessed `__origin__` unconditionally. Switched to `getattr` with a default so bare types return False.

`resolve_forward_ref` called `__builtins__.copy()`, which fails in `__main__` and many embedding contexts where `__builtins__` is the builtins module rather than its dict. Added an isinstance check to handle both forms.

Added parametrized tests covering bare types and subscripted tuple variants in test_typehints.py.

## Before submitting

- [x] Did you read the contributing guideline?
- [x] Did you write unit tests?
- [x] Did you verify that new and existing tests pass locally?
- [x] Did you make sure that all changes preserve backward compatibility?