### PR TITLE
Fix instance defaults not converted to dict for keyword-only parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Fixed
 - Misleading error message for ``parse_optionals_as_positionals=True`` and
   unrecognized non-positional arguments (`#922
   <https://github.com/mauvilsa/jsonargparse/pull/922>`__).
+- Fix subclass instance defaults not being converted to dict format when the
+  parameter is keyword-only (declared after ``*``) (`#933
+  <https://github.com/mauvilsa/jsonargparse/pull/933>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -739,6 +739,9 @@ class ParametersVisitor(LoggerProperty, ast.NodeVisitor):
         arg_nodes = getattr(node, "posonlyargs", []) + node.args
         default_nodes = [None] * (len(arg_nodes) - len(node.defaults)) + node.defaults
         default_nodes = [d for n, d in enumerate(default_nodes) if arg_nodes[n].arg in param_names]
+        for kw_arg, kw_default in zip(node.kwonlyargs, node.kw_defaults):
+            if kw_arg.arg in param_names and kw_default is not None:
+                default_nodes.append(kw_default)
         return default_nodes
 
     def get_kwargs_pop_or_get_parameter(self, node, component, parent, doc_params):

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -740,6 +740,23 @@ def test_get_params_class_instance_defaults(subtests):
         assert is_lambda(params[8].default)
 
 
+class ClassInstanceDefaultsKwOnly:
+    def __init__(
+        self,
+        pos_inst: BaseC = BaseC(p=1),
+        *,
+        kw_inst: BaseC = BaseC(p=2),
+    ):
+        pass  # pragma: no cover
+
+
+def test_get_params_class_instance_defaults_kw_only():
+    params = get_params(ClassInstanceDefaultsKwOnly)
+    assert_params(params, ["pos_inst", "kw_inst"], help=False)
+    assert params[0].default == dict(class_path=f"{__name__}.BaseC", init_args=dict(p=1))
+    assert params[1].default == dict(class_path=f"{__name__}.BaseC", init_args=dict(p=2))
+
+
 def test_get_params_class_conditional_global_constant():
     params = get_params(ConditionalGlobalConstant)
     assert ["p1", "p3"] == [p.name for p in params]


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
