### PR TITLE
Fix TypeError for parameters that have a default and non-runtime_checkable protocol type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ The semantic versioning only considers the public API as described in
 paths are considered internals and can change in minor and patch releases.
 
 
+v4.50.1 (unreleased)
+--------------------
+
+Fixed
+^^^^^
+- ``TypeError`` when adding arguments for a class that has a parameter that has
+  a default and is annotated with a non-``@runtime_checkable`` ``Protocol`` type
+  (`#935 <https://github.com/mauvilsa/jsonargparse/pull/935>`__).
+
+
 v4.50.0 (2026-07-22)
 --------------------
 

--- a/jsonargparse/_parameter_resolvers.py
+++ b/jsonargparse/_parameter_resolvers.py
@@ -382,12 +382,12 @@ ast_literals = {ast.dump(ast.parse(v, mode="eval").body): partial(ast.literal_ev
 
 
 def is_param_subclass_instance_default(param: ParamData) -> bool:
-    from ._typehints import ActionTypeHint, get_optional_arg, get_subclass_types
+    from ._typehints import ActionTypeHint, get_optional_arg, get_subclass_types, is_instance_or_supports_protocol
 
     annotation = get_optional_arg(param.annotation)
     class_types = get_subclass_types(annotation, callable_return=True)
     return bool(
-        (class_types and isinstance(param.default, class_types))
+        (class_types and any(is_instance_or_supports_protocol(param.default, ct) for ct in class_types))
         or (
             is_lambda(param.default)
             and ActionTypeHint.is_callable_typehint(annotation)

--- a/jsonargparse_tests/test_parameter_resolvers.py
+++ b/jsonargparse_tests/test_parameter_resolvers.py
@@ -4,14 +4,19 @@ import calendar
 import inspect
 import xml.dom
 from random import shuffle
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Protocol, Union
 from unittest.mock import patch
 
 import pytest
 
 from jsonargparse import Namespace, class_from_function
 from jsonargparse._optionals import docstring_parser_support
-from jsonargparse._parameter_resolvers import ConditionalDefault, is_lambda
+from jsonargparse._parameter_resolvers import (
+    ConditionalDefault,
+    ParamData,
+    is_lambda,
+    is_param_subclass_instance_default,
+)
 from jsonargparse._parameter_resolvers import get_signature_parameters as get_params
 from jsonargparse_tests.conftest import BaseClass, capture_logs, source_unavailable, wrap_fn
 
@@ -1017,3 +1022,44 @@ def test_get_params_failures():
     pytest.raises(ValueError, lambda: get_params("invalid"))
     pytest.raises(ValueError, lambda: get_params(Param, "p1"))
     pytest.raises(AttributeError, lambda: get_params(Param, "p2"))
+
+
+# non-runtime-checkable protocol tests
+
+
+class _NonRTCheckableProtocol(Protocol):
+    """A Protocol without @runtime_checkable, like openai's Client in strands."""
+
+    def execute(self) -> None: ...
+
+
+class _ConcreteImpl:
+    """Implements _NonRTCheckableProtocol structurally."""
+
+    def execute(self) -> None:
+        pass
+
+
+class _DoesNotImpl:
+    """Does NOT implement _NonRTCheckableProtocol."""
+
+
+@pytest.mark.parametrize(
+    "default, expected",
+    [
+        (None, False),  # falsy: None doesn't implement the protocol
+        (False, False),  # falsy non-None: bool doesn't implement the protocol
+        (_ConcreteImpl(), True),  # structurally implements the protocol → True
+        (_DoesNotImpl(), False),  # does not implement the protocol → False
+    ],
+    ids=["none_default", "false_default", "implementing_instance", "non_implementing_instance"],
+)
+def test_is_param_subclass_instance_default_non_runtime_checkable_protocol(default, expected):
+    param = ParamData(
+        name="client",
+        annotation=Optional[_NonRTCheckableProtocol],
+        default=default,
+        kind=inspect.Parameter.KEYWORD_ONLY,
+        component=None,
+    )
+    assert is_param_subclass_instance_default(param) is expected


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
