### PR TITLE
Fix TypedDict with keys inherited from a base defined in a different module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,8 +28,9 @@ Changed
 ^^^^^^^
 - Signature parameters with a type hint that fails to resolve, e.g. a missing
   import or a typo in a postponed annotation, are now accepted with the
-  unresolved parts replaced by ``Any``, instead of the parameter being silently
-  skipped (`#936 <https://github.com/mauvilsa/jsonargparse/pull/936>`__).
+  unresolved parts replaced by ``Any``, instead of the parameter being skipped
+  or, when mandatory and ``fail_untyped=True``, raising a ``ValueError`` (`#936
+  <https://github.com/mauvilsa/jsonargparse/pull/936>`__).
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,16 @@ Fixed
 - ``TypeError`` when adding arguments for a class that has a parameter that has
   a default and is annotated with a non-``@runtime_checkable`` ``Protocol`` type
   (`#935 <https://github.com/mauvilsa/jsonargparse/pull/935>`__).
+- ``TypedDict`` keys inherited from a base defined in a different module not
+  resolving the types only imported in the ``TYPE_CHECKING`` block of that
+  module (`#936 <https://github.com/mauvilsa/jsonargparse/pull/936>`__).
+
+Changed
+^^^^^^^
+- Signature parameters with a type hint that fails to resolve, e.g. a missing
+  import or a typo in a postponed annotation, are now accepted with the
+  unresolved parts replaced by ``Any``, instead of the parameter being silently
+  skipped (`#936 <https://github.com/mauvilsa/jsonargparse/pull/936>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_postponed_annotations.py
+++ b/jsonargparse/_postponed_annotations.py
@@ -243,22 +243,27 @@ def _enrich_globals_for_string_forward_refs(global_vars: dict[str, Any]) -> None
         _update_missing_from_module_vars(global_vars, missing, mod_vars)
 
 
+def update_module_global_vars(module: str, global_vars: dict, logger: logging.Logger | None) -> None:
+    """Adds to global_vars the names of a module, including those of its TYPE_CHECKING blocks."""
+    for key, value in vars(import_module(module)).items():  # needed for pydantic-v1
+        if key not in global_vars:
+            global_vars[key] = value
+    try:
+        module_source = inspect.getsource(sys.modules[module]) if module in sys.modules else ""
+        if "TYPE_CHECKING" in module_source:
+            TypeCheckingVisitor().update_aliases(module_source, module, global_vars, logger)
+    except Exception as ex:
+        if logger:
+            logger.debug(f"Failed to update aliases for TYPE_CHECKING blocks in {module}", exc_info=ex)
+
+
 def get_global_vars(obj: Any, logger: logging.Logger | None) -> dict:
     global_vars = getattr(obj, "__globals__", {}).copy()
     if is_dataclass(obj):
         next_mro = inspect.getmro(obj)[1]  # type: ignore[arg-type]
         if is_dataclass(next_mro):
             global_vars.update(get_global_vars(next_mro, logger))
-    for key, value in vars(import_module(obj.__module__)).items():  # needed for pydantic-v1
-        if key not in global_vars:
-            global_vars[key] = value
-    try:
-        module_source = inspect.getsource(sys.modules[obj.__module__]) if obj.__module__ in sys.modules else ""
-        if "TYPE_CHECKING" in module_source:
-            TypeCheckingVisitor().update_aliases(module_source, obj.__module__, global_vars, logger)
-    except Exception as ex:
-        if logger:
-            logger.debug(f"Failed to update aliases for TYPE_CHECKING blocks in {obj.__module__}", exc_info=ex)
+    update_module_global_vars(obj.__module__, global_vars, logger)
     _enrich_globals_for_string_forward_refs(global_vars)
     return global_vars
 

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -31,6 +31,7 @@ from ._typehints import (
     is_list_pathlike,
     is_optional,
     not_required_types,
+    replace_unresolved_forward_refs,
     sequence_origin_types,
     strip_required_typehint,
 )
@@ -339,6 +340,15 @@ class SignatureArguments(LoggerProperty):
         name = param.name
         kind = param.kind
         annotation = param.annotation
+        unresolved_replaced = replace_unresolved_forward_refs(annotation)
+        if unresolved_replaced is not annotation:
+            self.logger.debug(
+                f'Unable to resolve the type of parameter "{name}" from '
+                f'"{get_parameter_origins(param.component, param.parent)}": {annotation}. '
+                "The unresolved parts are replaced with Any, so the parameter is accepted "
+                "but its value is not validated."
+            )
+            annotation = unresolved_replaced
         if default == inspect_empty:
             default = param.default
             if default == inspect_empty:

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -839,40 +839,49 @@ def replace_unresolved_forward_refs(typehint):
         return Any
 
 
+def resolve_module_annotations(module: str, annotations: dict, global_vars: dict, logger=None) -> dict:
+    # A holder class is used so that only the given annotations are resolved, and with the
+    # names of a single module, which are given as localns to take precedence over the ones
+    # that get_type_hints takes from the module of each forward reference.
+    holder = type("holder", (), {"__annotations__": annotations, "__module__": module})
+    try:
+        # Resolves forward references (e.g. from "from __future__ import annotations"),
+        # while include_extras keeps the Required/NotRequired wrappers.
+        return get_type_hints(holder, None, global_vars, include_extras=True)
+    except Exception as ex:
+        if logger:
+            logger.debug(f"Failed to resolve the annotations {list(annotations)} from {module}", exc_info=ex)
+    # A single annotation failing (e.g. a missing import or a typo) makes the resolution
+    # of all of them fail. Thus, resolve one by one to keep the ones that do work.
+    return {k: resolve_forward_ref(v, global_vars) for k, v in annotations.items()}
+
+
 def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
     from ._postponed_annotations import get_global_vars, update_module_global_vars
 
-    # Includes the names from TYPE_CHECKING blocks, given as localns so that each base
-    # keeps resolving with the globals of the module in which it was defined.
-    global_vars = get_global_vars(typed_dict, logger)
-    # Keys inherited from a base defined in a different module also need the names of
-    # that module, including its TYPE_CHECKING blocks. The modules are taken from the
-    # forward references because a TypedDict does not keep its bases in __mro__, and
-    # __orig_bases__ is not available in all supported python versions. The names of the
-    # TypedDict's own module take precedence over the inherited ones.
-    inherited_modules = []
-    for annotation in typed_dict.__annotations__.values():
+    # Keys can be inherited from bases defined in other modules, and each key must resolve
+    # with the names of the module in which it was defined, including its TYPE_CHECKING
+    # blocks. Thus, the keys are grouped by module and resolved one group at a time, such
+    # that the names of one module never shadow the names of another. The modules are taken
+    # from the forward references because a TypedDict does not keep its bases in __mro__,
+    # and __orig_bases__ is not available in all supported python versions.
+    keys_per_module: dict[str, dict] = {}
+    for key, annotation in typed_dict.__annotations__.items():
         module = getattr(annotation, "__forward_module__", None)
         module = getattr(module, "__name__", module)
-        if isinstance(module, str) and module != typed_dict.__module__ and module not in inherited_modules:
-            inherited_modules.append(module)
-    if inherited_modules:
-        inherited_vars: dict = {}
-        for module in inherited_modules:
-            update_module_global_vars(module, inherited_vars, logger)
-        for key, value in inherited_vars.items():
-            if key not in global_vars:
-                global_vars[key] = value
-    try:
-        # Resolves forward references (e.g. from "from __future__ import annotations") and
-        # gathers inherited keys, while include_extras keeps the Required/NotRequired wrappers.
-        return get_type_hints(typed_dict, None, global_vars, include_extras=True)
-    except Exception as ex:
-        if logger:
-            logger.debug(f"Failed to resolve the annotations of {typed_dict}", exc_info=ex)
-    # A single key failing (e.g. a missing import or a typo) makes the resolution of the
-    # entire TypedDict fail. Thus, resolve one by one to keep the keys that do work.
-    return {k: resolve_forward_ref(v, global_vars) for k, v in typed_dict.__annotations__.items()}
+        if not isinstance(module, str):
+            module = typed_dict.__module__
+        keys_per_module.setdefault(module, {})[key] = annotation
+
+    annotations: dict = {}
+    for module, module_annotations in keys_per_module.items():
+        if module == typed_dict.__module__:
+            global_vars = get_global_vars(typed_dict, logger)
+        else:
+            global_vars = {}
+            update_module_global_vars(module, global_vars, logger)
+        annotations.update(resolve_module_annotations(module, module_annotations, global_vars, logger))
+    return {k: annotations[k] for k in typed_dict.__annotations__}
 
 
 def get_typed_dict_required_keys(typed_dict, annotations: dict) -> set:

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -814,12 +814,55 @@ def resolve_forward_ref(ref, global_vars=None):
     return aliases.get(ref.__forward_arg__, ref)
 
 
+def replace_unresolved_forward_refs(typehint):
+    """Replaces the unresolved forward references of a type hint with Any.
+
+    Postponed annotations that fail to resolve, e.g. because of a missing import or a
+    typo, remain as a string or a ForwardRef. Replacing only the unresolved parts with
+    Any keeps the parameter usable, though without validation, instead of discarding it.
+    """
+    if isinstance(typehint, (str, ForwardRef)):
+        return Any
+    if get_typehint_origin(typehint) in literal_types:
+        return typehint  # the args of a Literal are values, not types
+    args = getattr(typehint, "__args__", None)
+    if not args:
+        return typehint
+    new_args = tuple(replace_unresolved_forward_refs(a) for a in args)
+    if new_args == args:
+        return typehint
+    try:
+        if hasattr(typehint, "copy_with"):
+            return typehint.copy_with(new_args)
+        return get_typehint_origin(typehint)[new_args]
+    except Exception:
+        return Any
+
+
 def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
-    from ._postponed_annotations import get_global_vars
+    from ._postponed_annotations import get_global_vars, update_module_global_vars
 
     # Includes the names from TYPE_CHECKING blocks, given as localns so that each base
     # keeps resolving with the globals of the module in which it was defined.
     global_vars = get_global_vars(typed_dict, logger)
+    # Keys inherited from a base defined in a different module also need the names of
+    # that module, including its TYPE_CHECKING blocks. The modules are taken from the
+    # forward references because a TypedDict does not keep its bases in __mro__, and
+    # __orig_bases__ is not available in all supported python versions. The names of the
+    # TypedDict's own module take precedence over the inherited ones.
+    inherited_modules = []
+    for annotation in typed_dict.__annotations__.values():
+        module = getattr(annotation, "__forward_module__", None)
+        module = getattr(module, "__name__", module)
+        if isinstance(module, str) and module != typed_dict.__module__ and module not in inherited_modules:
+            inherited_modules.append(module)
+    if inherited_modules:
+        inherited_vars: dict = {}
+        for module in inherited_modules:
+            update_module_global_vars(module, inherited_vars, logger)
+        for key, value in inherited_vars.items():
+            if key not in global_vars:
+                global_vars[key] = value
     try:
         # Resolves forward references (e.g. from "from __future__ import annotations") and
         # gathers inherited keys, while include_extras keeps the Required/NotRequired wrappers.

--- a/jsonargparse_tests/different_module_type_checking.py
+++ b/jsonargparse_tests/different_module_type_checking.py
@@ -1,0 +1,24 @@
+from __future__ import annotations  # keep
+
+from typing import TYPE_CHECKING, TypedDict
+
+from jsonargparse._typehints import Required
+
+if TYPE_CHECKING:  # pragma: no cover
+    from decimal import Decimal
+
+    class TypeCheckingOnlyInDifferentModule:
+        pass
+
+
+class DifferentModuleTypeCheckingTypedDict(TypedDict, total=False):
+    """Base for a TypedDict that is inherited in a different module.
+
+    The postponed annotations below are only resolvable from the names of the
+    TYPE_CHECKING block of this module, ``only_in_base`` in particular not being
+    available anywhere else. Inherited in test_postponed_annotations.
+    """
+
+    name: Required[str]
+    amount: Decimal
+    only_in_base: TypeCheckingOnlyInDifferentModule

--- a/jsonargparse_tests/different_module_type_checking.py
+++ b/jsonargparse_tests/different_module_type_checking.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:  # pragma: no cover
         pass
 
 
+class SameNameInBothModules:
+    defined_in = "base"
+
+
 class DifferentModuleTypeCheckingTypedDict(TypedDict, total=False):
     """Base for a TypedDict that is inherited in a different module.
 
@@ -22,3 +26,4 @@ class DifferentModuleTypeCheckingTypedDict(TypedDict, total=False):
     name: Required[str]
     amount: Decimal
     only_in_base: TypeCheckingOnlyInDifferentModule
+    same_name_in_base: SameNameInBothModules

--- a/jsonargparse_tests/test_postponed_annotations.py
+++ b/jsonargparse_tests/test_postponed_annotations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # keep
 
 import dataclasses
+import decimal
 import importlib.util
 import os
 import sys
@@ -11,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from jsonargparse import Namespace
+from jsonargparse import ArgumentError, Namespace
 from jsonargparse import _postponed_annotations as postponed_annotations
 from jsonargparse._optionals import docstring_parser_support
 from jsonargparse._parameter_resolvers import get_signature_parameters as get_params
@@ -26,9 +27,15 @@ from jsonargparse._postponed_annotations import (
     get_types,
     type_requires_eval,
 )
-from jsonargparse._typehints import Unpack, get_typed_dict_annotations
+from jsonargparse._typehints import (
+    Required,
+    Unpack,
+    get_typed_dict_annotations,
+    get_typed_dict_required_keys,
+)
 from jsonargparse.typing import Path_drw
 from jsonargparse_tests.conftest import capture_logs, source_unavailable
+from jsonargparse_tests.different_module_type_checking import DifferentModuleTypeCheckingTypedDict
 from jsonargparse_tests.test_dataclasses import DifferentModuleBaseData
 
 
@@ -327,8 +334,68 @@ class UnresolvableTypedDictClass:
 @pytest.mark.skipif(not Unpack, reason="Unpack introduced in python 3.11 or backported in typing_extensions")
 def test_typed_dict_unresolvable_key_unpack(parser):
     added = parser.add_class_arguments(UnresolvableTypedDictClass, "cls")
-    assert added == ["cls.num"]  # the unresolvable key is skipped
+    assert added == ["cls.num", "cls.typo"]  # the unresolvable key falls back to Any
+    cfg = parser.parse_args(["--cls.num=1", "--cls.typo=abc"])
+    assert cfg.cls == Namespace(num=1, typo="abc")
+    # being Any, the unresolvable key accepts any value without validation
+    cfg = parser.parse_args(["--cls.num=1", '--cls.typo={"x": [1, 2]}'])
+    assert cfg.cls.typo == {"x": [1, 2]}
+    # and it remains not required, since the key is not required
     assert parser.parse_args(["--cls.num=1"]).cls == Namespace(num=1)
+
+
+def function_unresolvable_annotation(num: int = 1, typo: "MisspelledType" = None):  # type: ignore[name-defined]  # noqa: F821
+    return num  # pragma: no cover
+
+
+def test_function_unresolvable_annotation_falls_back_to_any(parser):
+    added = parser.add_function_arguments(function_unresolvable_annotation, "fn")
+    assert added == ["fn.num", "fn.typo"]  # the unresolvable annotation falls back to Any
+    cfg = parser.parse_args(["--fn.typo=abc"])
+    assert cfg.fn == Namespace(num=1, typo="abc")
+
+
+def test_unresolvable_annotation_debug_log(parser, logger):
+    parser.logger = logger
+    with capture_logs(logger) as logs:
+        parser.add_function_arguments(function_unresolvable_annotation, "fn")
+    assert "Unable to resolve the type of parameter" in logs.getvalue()
+    assert "typo" in logs.getvalue()
+
+
+# A TypedDict that inherits from a TypedDict in a different module must resolve the
+# names of that module's TYPE_CHECKING block, not only the names of its own module.
+
+
+class InheritDifferentModuleTypedDict(DifferentModuleTypeCheckingTypedDict, total=False):
+    extra: bool
+
+
+class InheritDifferentModuleTypedDictClass:
+    def __init__(self, **kwargs: Unpack[InheritDifferentModuleTypedDict]) -> None:
+        self.kwargs = kwargs  # pragma: no cover
+
+
+def test_get_typed_dict_annotations_inherit_different_module_type_checking():
+    annotations = get_typed_dict_annotations(InheritDifferentModuleTypedDict)
+    assert annotations["name"] == Required[str]
+    assert annotations["amount"] is decimal.Decimal
+    assert annotations["extra"] is bool
+    # only_in_base is exclusive to the TYPE_CHECKING block of the base class' module
+    assert annotations["only_in_base"].__name__ == "TypeCheckingOnlyInDifferentModule"
+    required_keys = get_typed_dict_required_keys(InheritDifferentModuleTypedDict, annotations)
+    assert required_keys == {"name"}
+
+
+@pytest.mark.skipif(not Unpack, reason="Unpack introduced in python 3.11 or backported in typing_extensions")
+def test_typed_dict_inherit_different_module_type_checking_unpack(parser):
+    added = parser.add_class_arguments(InheritDifferentModuleTypedDictClass, "cls")
+    assert added == ["cls.name", "cls.amount", "cls.only_in_base", "cls.extra"]
+    cfg = parser.parse_args(["--cls.name=x", "--cls.amount=1.5", "--cls.extra=true"])
+    assert cfg.cls == Namespace(name="x", amount=decimal.Decimal("1.5"), extra=True)
+    # the key wrapped in Required stays required even though the bases are total=False
+    with pytest.raises(ArgumentError, match="required: cls.name"):
+        parser.parse_args(["--cls.amount=1.5"])
 
 
 def function_type_checking_type(p1: Type["TypeCheckingClass2"]):

--- a/jsonargparse_tests/test_postponed_annotations.py
+++ b/jsonargparse_tests/test_postponed_annotations.py
@@ -5,9 +5,10 @@ import decimal
 import importlib.util
 import os
 import sys
+from collections.abc import Callable
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Dict, ForwardRef, List, Optional, Tuple, Type, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, ForwardRef, List, Optional, Tuple, Type, TypedDict, Union
 from unittest.mock import patch
 
 import pytest
@@ -32,6 +33,7 @@ from jsonargparse._typehints import (
     Unpack,
     get_typed_dict_annotations,
     get_typed_dict_required_keys,
+    replace_unresolved_forward_refs,
 )
 from jsonargparse.typing import Path_drw
 from jsonargparse_tests.conftest import capture_logs, source_unavailable
@@ -363,12 +365,48 @@ def test_unresolvable_annotation_debug_log(parser, logger):
     assert "typo" in logs.getvalue()
 
 
+# When only a subtype fails to resolve, the rest of the type hint is kept so that what is
+# resolvable is still validated. How the type hint is rebuilt depends on its kind, i.e.
+# typing generic aliases have copy_with, the builtin ones are subscripted again, and
+# collections.abc.Callable does not accept an Any argument, so it falls back entirely to Any.
+
+
+def function_unresolvable_subtype(
+    p1: List["MisspelledType"],  # type: ignore[name-defined]  # noqa: F821
+    p2: list["MisspelledType"],  # type: ignore[name-defined]  # noqa: F821
+    p3: Callable[["MisspelledType"], int],  # type: ignore[name-defined]  # noqa: F821
+):
+    return p1, p2, p3  # pragma: no cover
+
+
+def test_unresolvable_subtype_replaced_with_any():
+    annotations = {p.name: p.annotation for p in get_params(function_unresolvable_subtype)}
+    assert replace_unresolved_forward_refs(annotations["p1"]) == List[Any]
+    assert replace_unresolved_forward_refs(annotations["p2"]) == list[Any]
+    assert replace_unresolved_forward_refs(annotations["p3"]) is Any
+
+
+def test_unresolvable_subtype_parse(parser):
+    added = parser.add_function_arguments(function_unresolvable_subtype, "fn")
+    assert added == ["fn.p1", "fn.p2", "fn.p3"]
+    cfg = parser.parse_args(["--fn.p1=[1]", '--fn.p2=["a"]', "--fn.p3=anything"])
+    assert cfg.fn == Namespace(p1=[1], p2=["a"], p3="anything")
+    # the resolvable part of the type hint is still validated
+    with pytest.raises(ArgumentError, match="Expected a <class 'list'>"):
+        parser.parse_args(["--fn.p1=1", "--fn.p2=[]", "--fn.p3=x"])
+
+
 # A TypedDict that inherits from a TypedDict in a different module must resolve the
 # names of that module's TYPE_CHECKING block, not only the names of its own module.
 
 
+class SameNameInBothModules:
+    defined_in = "derived"
+
+
 class InheritDifferentModuleTypedDict(DifferentModuleTypeCheckingTypedDict, total=False):
     extra: bool
+    same_name_in_derived: SameNameInBothModules
 
 
 class InheritDifferentModuleTypedDictClass:
@@ -387,10 +425,24 @@ def test_get_typed_dict_annotations_inherit_different_module_type_checking():
     assert required_keys == {"name"}
 
 
+def test_get_typed_dict_annotations_same_name_in_both_modules():
+    annotations = get_typed_dict_annotations(InheritDifferentModuleTypedDict)
+    # a name defined in both modules resolves to the one of the module that defines the key
+    assert annotations["same_name_in_base"].defined_in == "base"
+    assert annotations["same_name_in_derived"] is SameNameInBothModules
+
+
 @pytest.mark.skipif(not Unpack, reason="Unpack introduced in python 3.11 or backported in typing_extensions")
 def test_typed_dict_inherit_different_module_type_checking_unpack(parser):
     added = parser.add_class_arguments(InheritDifferentModuleTypedDictClass, "cls")
-    assert added == ["cls.name", "cls.amount", "cls.only_in_base", "cls.extra"]
+    assert added == [
+        "cls.name",
+        "cls.amount",
+        "cls.only_in_base",
+        "cls.same_name_in_base",
+        "cls.extra",
+        "cls.same_name_in_derived",
+    ]
     cfg = parser.parse_args(["--cls.name=x", "--cls.amount=1.5", "--cls.extra=true"])
     assert cfg.cls == Namespace(name="x", amount=decimal.Decimal("1.5"), extra=True)
     # the key wrapped in Required stays required even though the bases are total=False


### PR DESCRIPTION
## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
